### PR TITLE
Resizing with orientation

### DIFF
--- a/android/src/main/java/fr/bamlab/rnimageresizer/ImageResizer.java
+++ b/android/src/main/java/fr/bamlab/rnimageresizer/ImageResizer.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Matrix;
+import android.media.ExifInterface;
 import android.media.ThumbnailUtils;
 
 import java.io.ByteArrayOutputStream;
@@ -100,6 +101,35 @@ class ImageResizer {
                                             int quality, int rotation) throws IOException {
 
         Bitmap resizedImage = ImageResizer.rotateImage(ImageResizer.resizeImage(imagePath, newWidth, newHeight), rotation);
+        return ImageResizer.saveImage(resizedImage, context.getCacheDir(),
+                Long.toString(new Date().getTime()), compressFormat, quality);
+    }
+
+    public static String createResizedImageUsingOrientation(Context context, String imagePath, int newWidth,
+                                                            int newHeight, Bitmap.CompressFormat compressFormat,
+                                                            int quality, int rotation) throws IOException {
+
+        int orientationRotation = 0;
+        File imageFile = new File(imagePath);
+
+        ExifInterface exif = new ExifInterface(imageFile.getAbsolutePath());
+        int orientation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL);
+
+        switch (orientation) {
+            case ExifInterface.ORIENTATION_ROTATE_90:
+                orientationRotation = 90;
+                break;
+            case ExifInterface.ORIENTATION_ROTATE_180:
+                orientationRotation = 180;
+                break;
+            case ExifInterface.ORIENTATION_ROTATE_270:
+                orientationRotation = 270;
+                break;
+        }
+
+        orientationRotation = orientationRotation + rotation;
+
+        Bitmap resizedImage = ImageResizer.rotateImage(ImageResizer.resizeImage(imagePath, newWidth, newHeight), orientationRotation);
         return ImageResizer.saveImage(resizedImage, context.getCacheDir(),
                 Long.toString(new Date().getTime()), compressFormat, quality);
     }

--- a/android/src/main/java/fr/bamlab/rnimageresizer/ImageResizerModule.java
+++ b/android/src/main/java/fr/bamlab/rnimageresizer/ImageResizerModule.java
@@ -41,12 +41,34 @@ class ImageResizerModule extends ReactContextBaseJavaModule {
         }
     }
 
+    @ReactMethod
+    public void createResizedImageUsingOrientation(String imagePath, int newWidth, int newHeight, String compressFormat,
+                            int quality, int rotation, final Callback successCb, final Callback failureCb) {
+        try {
+            createResizedImageUsingOrientationWithExceptions(imagePath, newWidth, newHeight, compressFormat, quality,
+                    rotation, successCb, failureCb);
+        } catch (IOException e) {
+            failureCb.invoke(e.getMessage());
+        }
+    }
+
     private void createResizedImageWithExceptions(String imagePath, int newWidth, int newHeight,
                                            String compressFormatString, int quality, int rotation,
                                            final Callback successCb, final Callback failureCb) throws IOException {
         Bitmap.CompressFormat compressFormat = Bitmap.CompressFormat.valueOf(compressFormatString);
         imagePath = imagePath.replace("file:", "");
         String resizedImagePath = ImageResizer.createResizedImage(this.context, imagePath, newWidth,
+                newHeight, compressFormat, quality, rotation);
+
+        successCb.invoke("file:" + resizedImagePath);
+    }
+
+    private void createResizedImageUsingOrientationWithExceptions(String imagePath, int newWidth, int newHeight,
+                                           String compressFormatString, int quality, int rotation,
+                                           final Callback successCb, final Callback failureCb) throws IOException {
+        Bitmap.CompressFormat compressFormat = Bitmap.CompressFormat.valueOf(compressFormatString);
+        imagePath = imagePath.replace("file:", "");
+        String resizedImagePath = ImageResizer.createResizedImageUsingOrientation(this.context, imagePath, newWidth,
                 newHeight, compressFormat, quality, rotation);
 
         successCb.invoke("file:" + resizedImagePath);

--- a/index.android.js
+++ b/index.android.js
@@ -9,4 +9,10 @@ export default {
         compressFormat, quality, rotation, resolve, reject);
     });
   },
+  createResizedImageUsingOrientation: (imagePath, newWidth, newHeight, compressFormat, quality, rotation = 0) => {
+    return new Promise((resolve, reject) => {
+      ImageResizerAndroid.createResizedImageUsingOrientation(imagePath, newWidth, newHeight,
+        compressFormat, quality, rotation, resolve, reject);
+    });
+  },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-image-resizer",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Rescale local images with React Native",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I was running into some issues sizing images from the camera, they would already be rotated based on the camera/ExifInterface orientation.

Created the method `createResizedImageUsingOrientation` which takes the same parameters, but looks at the image's ExifInterface orientation, so if no rotation is passed, the image will be "upright" based on how you took it.

Haven't used the library on iOS yet, so not sure if that platform has the same issue.