### PR TITLE
Add outputPath to options

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ public class MainActivity extends Activity implements DefaultHardwareBackBtnHand
 ```javascript
 import ImageResizer from 'react-native-image-resizer';
 
-ImageResizer.createResizedImage(imageUri, outputPath, newWidth, newHeight, compressFormat, quality).then((resizedImageUri) => {
+ImageResizer.createResizedImage(imageUri, newWidth, newHeight, compressFormat, quality, rotation, outputPath).then((resizedImageUri) => {
   // resizeImageUri is the URI of the new image that can now be displayed, uploaded...
 }).catch((err) => {
   // Oops, something went wrong. Check that the filename is correct and
@@ -117,7 +117,7 @@ A basic, sample app is available in [the `example` folder](https://github.com/ba
 
 ## API
 
-### `promise createResizedImage(path, outputPath, maxWidth, maxHeight, compressFormat, quality, rotation = 0)`
+### `promise createResizedImage(path, maxWidth, maxHeight, compressFormat, quality, rotation = 0, outputPath)`
 
 The promise resolves with a string containing the uri of the new file.
 

--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ The promise resolves with a string containing the uri of the new file.
 Option | Description
 ------ | -----------
 path | Path of image
-outputPath | The resized image path. If null, resized image will be stored in cache folder
 maxWidth | Image max width (ratio is preserved)
 maxHeight | Image max height (ratio is preserved)
 compressFormat | Can be either JPEG, PNG (android only) or WEBP (android only).
 quality | A number between 0 and 100. Used for the JPEG compression.
 rotation | Rotation to apply to the image, in degrees, for android only. On iOS, the resizing is done such that the orientation is always up.
+outputPath | The resized image path. If null, resized image will be stored in cache folder. To set outputPath make sure to add option for rotation too (if no rotation is needed, just set it to 0).

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ public class MainActivity extends Activity implements DefaultHardwareBackBtnHand
 ```javascript
 import ImageResizer from 'react-native-image-resizer';
 
-ImageResizer.createResizedImage(imageUri, newWidth, newHeight, compressFormat, quality).then((resizedImageUri) => {
+ImageResizer.createResizedImage(imageUri, outputPath, newWidth, newHeight, compressFormat, quality).then((resizedImageUri) => {
   // resizeImageUri is the URI of the new image that can now be displayed, uploaded...
 }).catch((err) => {
   // Oops, something went wrong. Check that the filename is correct and
@@ -117,12 +117,16 @@ A basic, sample app is available in [the `example` folder](https://github.com/ba
 
 ## API
 
-### `promise createResizedImage(path, maxWidth, maxHeight, compressFormat, quality, rotation = 0)`
-
-Open the image at the given path and resize it so that it is less than the specified `maxWidth` and `maxHeight` (i.e: ratio is preserved). `compressFormat` is either `JPEG`, `PNG` (android only) or `WEBP` (android only).
-
-`quality` is a number between 0 and 100, used for the JPEG compression.
-
-`rotation` is the rotation to apply to the image, in degrees, for android only. On iOS, the resizing is done such that the orientation is always up.
+### `promise createResizedImage(path, outputPath, maxWidth, maxHeight, compressFormat, quality, rotation = 0)`
 
 The promise resolves with a string containing the uri of the new file.
+
+Option | Description
+------ | -----------
+path | Path of image
+outputPath | The resized image path. If null, resized image will be stored in cache folder
+maxWidth | Image max width (ratio is preserved)
+maxHeight | Image max height (ratio is preserved)
+compressFormat | Can be either JPEG, PNG (android only) or WEBP (android only).
+quality | A number between 0 and 100. Used for the JPEG compression.
+rotation | Rotation to apply to the image, in degrees, for android only. On iOS, the resizing is done such that the orientation is always up.

--- a/android/src/main/java/fr/bamlab/rnimageresizer/ImageResizer.java
+++ b/android/src/main/java/fr/bamlab/rnimageresizer/ImageResizer.java
@@ -102,12 +102,18 @@ class ImageResizer {
         return newFile.getAbsolutePath();
     }
 
-    public static String createResizedImage(Context context, String imagePath, int newWidth,
+    public static String createResizedImage(Context context, String imagePath, String outputPath, int newWidth,
                                             int newHeight, Bitmap.CompressFormat compressFormat,
                                             int quality, int rotation) throws IOException  {
 
         Bitmap resizedImage = ImageResizer.rotateImage(ImageResizer.resizeImage(imagePath, newWidth, newHeight,context), rotation);
-        return ImageResizer.saveImage(resizedImage, context.getCacheDir(),
+
+        File path = context.getCacheDir();
+        if (outputPath != null || !outputPath.isEmpty()) {
+          path = new File(outputPath);
+        }
+
+        return ImageResizer.saveImage(resizedImage, path,
                 Long.toString(new Date().getTime()), compressFormat, quality);
     }
 }

--- a/android/src/main/java/fr/bamlab/rnimageresizer/ImageResizer.java
+++ b/android/src/main/java/fr/bamlab/rnimageresizer/ImageResizer.java
@@ -102,11 +102,11 @@ class ImageResizer {
         return newFile.getAbsolutePath();
     }
 
-    public static String createResizedImage(Context context, String imagePath, String outputPath, int newWidth,
+    public static String createResizedImage(Context context, String imagePath, int newWidth,
                                             int newHeight, Bitmap.CompressFormat compressFormat,
-                                            int quality, int rotation) throws IOException  {
+                                            int quality, int rotation, String outputPath) throws IOException  {
 
-        Bitmap resizedImage = ImageResizer.rotateImage(ImageResizer.resizeImage(imagePath, newWidth, newHeight,context), rotation);
+        Bitmap resizedImage = ImageResizer.rotateImage(ImageResizer.resizeImage(imagePath, newWidth, newHeight, context), rotation);
 
         File path = context.getCacheDir();
         if (outputPath != null || !outputPath.isEmpty()) {

--- a/android/src/main/java/fr/bamlab/rnimageresizer/ImageResizerModule.java
+++ b/android/src/main/java/fr/bamlab/rnimageresizer/ImageResizerModule.java
@@ -31,22 +31,22 @@ class ImageResizerModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void createResizedImage(String imagePath, int newWidth, int newHeight, String compressFormat,
+    public void createResizedImage(String imagePath, String outputPath, int newWidth, int newHeight, String compressFormat,
                             int quality, int rotation, final Callback successCb, final Callback failureCb) {
         try {
-            createResizedImageWithExceptions(imagePath, newWidth, newHeight, compressFormat, quality,
+            createResizedImageWithExceptions(imagePath, outputPath, newWidth, newHeight, compressFormat, quality,
                     rotation, successCb, failureCb);
         } catch (IOException e) {
             failureCb.invoke(e.getMessage());
         }
     }
 
-    private void createResizedImageWithExceptions(String imagePath, int newWidth, int newHeight,
+    private void createResizedImageWithExceptions(String imagePath, String outputPath, int newWidth, int newHeight,
                                            String compressFormatString, int quality, int rotation,
                                            final Callback successCb, final Callback failureCb) throws IOException {
         Bitmap.CompressFormat compressFormat = Bitmap.CompressFormat.valueOf(compressFormatString);
         imagePath = imagePath.replace("file:", "");
-        String resizedImagePath = ImageResizer.createResizedImage(this.context, imagePath, newWidth,
+        String resizedImagePath = ImageResizer.createResizedImage(this.context, imagePath, outputPath, newWidth,
                 newHeight, compressFormat, quality, rotation);
 
         successCb.invoke("file:" + resizedImagePath);

--- a/android/src/main/java/fr/bamlab/rnimageresizer/ImageResizerModule.java
+++ b/android/src/main/java/fr/bamlab/rnimageresizer/ImageResizerModule.java
@@ -31,23 +31,23 @@ class ImageResizerModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void createResizedImage(String imagePath, String outputPath, int newWidth, int newHeight, String compressFormat,
-                            int quality, int rotation, final Callback successCb, final Callback failureCb) {
+    public void createResizedImage(String imagePath, int newWidth, int newHeight, String compressFormat,
+                            int quality, int rotation, String outputPath, final Callback successCb, final Callback failureCb) {
         try {
-            createResizedImageWithExceptions(imagePath, outputPath, newWidth, newHeight, compressFormat, quality,
-                    rotation, successCb, failureCb);
+            createResizedImageWithExceptions(imagePath, newWidth, newHeight, compressFormat, quality,
+                    rotation, outputPath, successCb, failureCb);
         } catch (IOException e) {
             failureCb.invoke(e.getMessage());
         }
     }
 
-    private void createResizedImageWithExceptions(String imagePath, String outputPath, int newWidth, int newHeight,
-                                           String compressFormatString, int quality, int rotation,
+    private void createResizedImageWithExceptions(String imagePath, int newWidth, int newHeight,
+                                           String compressFormatString, int quality, int rotation, String outputPath,
                                            final Callback successCb, final Callback failureCb) throws IOException {
         Bitmap.CompressFormat compressFormat = Bitmap.CompressFormat.valueOf(compressFormatString);
         imagePath = imagePath.replace("file:", "");
-        String resizedImagePath = ImageResizer.createResizedImage(this.context, imagePath, outputPath, newWidth,
-                newHeight, compressFormat, quality, rotation);
+        String resizedImagePath = ImageResizer.createResizedImage(this.context, imagePath, newWidth,
+                newHeight, compressFormat, quality, rotation, outputPath);
 
         successCb.invoke("file:" + resizedImagePath);
     }

--- a/index.android.js
+++ b/index.android.js
@@ -3,10 +3,10 @@ import React from 'react-native';
 const ImageResizerAndroid = React.NativeModules.ImageResizerAndroid;
 
 export default {
-  createResizedImage: (imagePath, outputPath, newWidth, newHeight, compressFormat, quality, rotation = 0) => {
+  createResizedImage: (imagePath, newWidth, newHeight, compressFormat, quality, rotation = 0, outputPath) => {
     return new Promise((resolve, reject) => {
-      ImageResizerAndroid.createResizedImage(imagePath, outputPath, newWidth, newHeight,
-        compressFormat, quality, rotation, resolve, reject);
+      ImageResizerAndroid.createResizedImage(imagePath, newWidth, newHeight,
+        compressFormat, quality, rotation, outputPath, resolve, reject);
     });
   },
 };

--- a/index.android.js
+++ b/index.android.js
@@ -3,9 +3,9 @@ import React from 'react-native';
 const ImageResizerAndroid = React.NativeModules.ImageResizerAndroid;
 
 export default {
-  createResizedImage: (imagePath, newWidth, newHeight, compressFormat, quality, rotation = 0) => {
+  createResizedImage: (imagePath, outputPath, newWidth, newHeight, compressFormat, quality, rotation = 0) => {
     return new Promise((resolve, reject) => {
-      ImageResizerAndroid.createResizedImage(imagePath, newWidth, newHeight,
+      ImageResizerAndroid.createResizedImage(imagePath, outputPath, newWidth, newHeight,
         compressFormat, quality, rotation, resolve, reject);
     });
   },

--- a/index.ios.js
+++ b/index.ios.js
@@ -3,13 +3,13 @@ import {
 } from 'react-native';
 
 export default {
-  createResizedImage: (path, outputPath, width, height, format, quality) => {
+  createResizedImage: (path, width, height, format, quality, rotation = 0, outputPath) => {
     if (format !== 'JPEG') {
       throw new Error('Only JPEG format is supported by createResizedImage');
     }
 
     return new Promise((resolve, reject) => {
-      NativeModules.ImageResizer.createResizedImage(path, outputPath, width, height, quality, (err, resizedPath) => {
+      NativeModules.ImageResizer.createResizedImage(path, width, height, quality, outputPath, (err, resizedPath) => {
         if (err) {
           return reject(err);
         }

--- a/index.ios.js
+++ b/index.ios.js
@@ -3,13 +3,13 @@ import {
 } from 'react-native';
 
 export default {
-  createResizedImage: (path, width, height, format, quality) => {
+  createResizedImage: (path, outputPath, width, height, format, quality) => {
     if (format !== 'JPEG') {
       throw new Error('Only JPEG format is supported by createResizedImage');
     }
 
     return new Promise((resolve, reject) => {
-      NativeModules.ImageResizer.createResizedImage(path, width, height, quality, (err, resizedPath) => {
+      NativeModules.ImageResizer.createResizedImage(path, outputPath, width, height, quality, (err, resizedPath) => {
         if (err) {
           return reject(err);
         }

--- a/ios/RCTImageResizer/RCTImageResizer.m
+++ b/ios/RCTImageResizer/RCTImageResizer.m
@@ -41,10 +41,10 @@ NSString * generateFilePath(NSString * ext, NSString * outputPath)
 }
 
 RCT_EXPORT_METHOD(createResizedImage:(NSString *)path
-                  outputPath:(NSString *)outputPath
                   width:(float)width
                   height:(float)height
                   quality:(float)quality
+                  outputPath:(NSString *)outputPath
                   callback:(RCTResponseSenderBlock)callback)
 {
     CGSize newSize = CGSizeMake(width, height);

--- a/ios/RCTImageResizer/RCTImageResizer.m
+++ b/ios/RCTImageResizer/RCTImageResizer.m
@@ -22,25 +22,33 @@ void saveImage(NSString * fullPath, UIImage * image, float quality)
     [fileManager createFileAtPath:fullPath contents:data attributes:nil];
 }
 
-NSString * generateCacheFilePath(NSString * ext)
+NSString * generateFilePath(NSString * ext, NSString * outputPath)
 {
-    NSArray* paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
-    NSString* cacheDirectory = [paths firstObject];
+    NSString* directory;
+
+    if ([outputPath length] == 0) {
+        NSArray* paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
+        directory = [paths firstObject];
+    } else {
+        directory = outputPath;
+    }
+
     NSString* name = [[NSUUID UUID] UUIDString];
     NSString* fullName = [NSString stringWithFormat:@"%@.%@", name, ext];
-    NSString* fullPath = [cacheDirectory stringByAppendingPathComponent:fullName];
+    NSString* fullPath = [directory stringByAppendingPathComponent:fullName];
 
     return fullPath;
 }
 
 RCT_EXPORT_METHOD(createResizedImage:(NSString *)path
+                  outputPath:(NSString *)outputPath
                   width:(float)width
                   height:(float)height
                   quality:(float)quality
                   callback:(RCTResponseSenderBlock)callback)
 {
     CGSize newSize = CGSizeMake(width, height);
-    NSString* fullPath = generateCacheFilePath(@"jpg");
+    NSString* fullPath = generateFilePath(@"jpg", outputPath);
 
     [_bridge.imageLoader loadImageWithTag:path callback:^(NSError *error, UIImage *image) {
         if (error || image == nil) {


### PR DESCRIPTION
Give option to specify output path of resized image. If set to null it uses default location.

I needed this for android because i couldn't move the resized image from the cache folder using react-native-fs. RNFS only allows you to perform operations inside the internal and external "files" folder. the cache folder is outside of those folders.

Needed it only for android but added for ios too. 