### PR TITLE
Fix iOS and Android bugs

### DIFF
--- a/android/src/main/java/fr/bamlab/rnimageresizer/ImageResizer.java
+++ b/android/src/main/java/fr/bamlab/rnimageresizer/ImageResizer.java
@@ -109,7 +109,7 @@ class ImageResizer {
         Bitmap resizedImage = ImageResizer.rotateImage(ImageResizer.resizeImage(imagePath, newWidth, newHeight, context), rotation);
 
         File path = context.getCacheDir();
-        if (outputPath != null || !outputPath.isEmpty()) {
+        if (outputPath != null) {
           path = new File(outputPath);
         }
 

--- a/ios/RCTImageResizer/RCTImageResizer.m
+++ b/ios/RCTImageResizer/RCTImageResizer.m
@@ -50,7 +50,7 @@ RCT_EXPORT_METHOD(createResizedImage:(NSString *)path
     CGSize newSize = CGSizeMake(width, height);
     NSString* fullPath = generateFilePath(@"jpg", outputPath);
 
-    [_bridge.imageLoader loadImageWithTag:path callback:^(NSError *error, UIImage *image) {
+    [_bridge.imageLoader loadImageWithURLRequest:path callback:^(NSError *error, UIImage *image) {
         if (error || image == nil) {
             if ([path hasPrefix:@"data:"] || [path hasPrefix:@"file:"]) {
                 NSURL *imageUrl = [[NSURL alloc] initWithString:path];

--- a/ios/RCTImageResizer/RCTImageResizer.m
+++ b/ios/RCTImageResizer/RCTImageResizer.m
@@ -50,6 +50,12 @@ RCT_EXPORT_METHOD(createResizedImage:(NSString *)path
     CGSize newSize = CGSizeMake(width, height);
     NSString* fullPath = generateFilePath(@"jpg", outputPath);
 
+    NSString* tempPath = NSTemporaryDirectory();
+    NSString* tempFile = [tempPath stringByAppendingPathComponent:path];
+    NSURL* fileUrl = [NSURL fileURLWithPath:tempFile];
+
+    NSURLRequest *request = [NSURLRequest requestWithURL:fileUrl];
+
     [_bridge.imageLoader loadImageWithURLRequest:path callback:^(NSError *error, UIImage *image) {
         if (error || image == nil) {
             if ([path hasPrefix:@"data:"] || [path hasPrefix:@"file:"]) {

--- a/ios/RCTImageResizer/RCTImageResizer.m
+++ b/ios/RCTImageResizer/RCTImageResizer.m
@@ -56,7 +56,7 @@ RCT_EXPORT_METHOD(createResizedImage:(NSString *)path
 
     NSURLRequest *request = [NSURLRequest requestWithURL:fileUrl];
 
-    [_bridge.imageLoader loadImageWithURLRequest:path callback:^(NSError *error, UIImage *image) {
+    [_bridge.imageLoader loadImageWithURLRequest:request callback:^(NSError *error, UIImage *image) {
         if (error || image == nil) {
             if ([path hasPrefix:@"data:"] || [path hasPrefix:@"file:"]) {
                 NSURL *imageUrl = [[NSURL alloc] initWithString:path];


### PR DESCRIPTION
Hi!

This PR fixes both #21 and #19. On the Android side `!outputPath.isEmpty()` caused a Null Pointer Exception if outputPath is null (might want to use &&, this is not tested with an outputPath). On the iOS side I started getting nasty errors after switching the deprecated `loadImageWithTag` method to `loadImageWithURLRequest` that I tracked down to the new method wanting an `NSURLRequest` object instead of a string. I fixed this with the help of StackOverflow, but as I am not an objective-c developer you might want to look over the code I added to transform the path string into a request object.

In short, with this PR the resizer works perfectly for my use cases, without using deprecated methods, on both iOS and Android running React-Native 0.29.