### PR TITLE
Fixed memory leaks and don't rotate unless necessary 

### DIFF
--- a/android/src/main/java/fr/bamlab/rnimageresizer/ImageResizer.java
+++ b/android/src/main/java/fr/bamlab/rnimageresizer/ImageResizer.java
@@ -27,7 +27,7 @@ import java.util.Date;
 class ImageResizer {
 
     private static Bitmap resizeImage(Bitmap image, int maxWidth, int maxHeight, Context context) {
-        Bitmap newImage;
+        Bitmap newImage = null;
 
         if (image == null) {
             return null; // Can't load the image from the given path.
@@ -174,10 +174,14 @@ class ImageResizer {
             sourceImage.recycle();
         }
 
-        // Rotate it
-        int orientation = getOrientation(context, Uri.parse(imagePath));
-        rotation = orientation + rotation;
-        Bitmap rotatedImage = ImageResizer.rotateImage(scaledImage, rotation);
+        // Rotate if neccesary
+        Bitmap rotatedImage = scaledImage;
+        if (rotation > 0) {
+            int orientation = getOrientation(context, Uri.parse(imagePath));
+            rotation = orientation + rotation;
+            rotatedImage = ImageResizer.rotateImage(scaledImage, rotation);
+        }
+
         if (scaledImage != rotatedImage) {
             scaledImage.recycle();
         }


### PR DESCRIPTION
There was a memory leak on resize image as the bitmap wasn't being recycled. I also refactored the code a bit so that recycling is done from one place: `createResizedImage`.  This makes memory management easier to manage. Lastly we don't need to call the rotate function if rotation is 0 degrees.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bamlab/react-native-image-resizer/25)
<!-- Reviewable:end -->
