### PR TITLE
Simplify readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,98 +4,10 @@ A React Native module that can create scaled versions of local images (also supp
 
 ## Setup
 
-First, install the package:
-```
-npm install react-native-image-resizer --save
-```
-
-### Automatic installation (iOS and Android)
-
-Use [rnpm](https://github.com/rnpm/rnpm):
-
+Install the package with [rnpm](https://github.com/rnpm/rnpm):
 ```
 npm install rnpm -g
-rnpm link
-```
-
-### Manual installation for iOS
-
-You need to add `RNImageResizer.xcodeproj` to **Libraries** and add `libRNImageResizer.a` to **Link Binary With Libraries** under **Build Phases**. [More info and screenshots about how to do this is available in the React Native documentation](http://facebook.github.io/react-native/docs/linking-libraries-ios.html#content).
-
-### Manual installation for Android
-
-#### Update your gradle files
-
-For **react-native >= v0.15**, this command will do it automatically:
-```
-react-native link react-native-image-resizer
-```
-
-For **react-native = v0.14**
-You will have to update them manually:
-
-In `android/settings.gradle`, add:
-```
-include ':react-native-image-resizer'
-project(':react-native-image-resizer').projectDir = new File(settingsDir, '../node_modules/react-native-image-resizer/android')
-```
-
-In `android/app/build.gradle` add:
-```
-dependencies {
-  ...
-  compile project(':react-native-image-resizer')
-}
-```
-
-#### Register the package into your `MainActivity`
-```java
-package com.example;
-
-import android.app.Activity;
-import android.os.Bundle;
-import android.view.KeyEvent;
-
-import com.facebook.react.LifecycleState;
-import com.facebook.react.ReactInstanceManager;
-import com.facebook.react.ReactRootView;
-import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
-import com.facebook.react.shell.MainReactPackage;
-import com.facebook.soloader.SoLoader;
-
-// IMPORT HERE
-import fr.bamlab.rnimageresizer.ImageResizerPackage;
-// ---
-
-public class MainActivity extends Activity implements DefaultHardwareBackBtnHandler {
-
-    private ReactInstanceManager mReactInstanceManager;
-    private ReactRootView mReactRootView;
-
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        mReactRootView = new ReactRootView(this);
-
-        mReactInstanceManager = ReactInstanceManager.builder()
-                .setApplication(getApplication())
-                .setBundleAssetName("index.android.bundle")
-                .setJSMainModuleName("index.android")
-                .addPackage(new MainReactPackage())
-
-                // REGISTER PACKAGE HERE
-                .addPackage(new ImageResizerPackage())
-                // ---
-                .setUseDeveloperSupport(BuildConfig.DEBUG)
-                .setInitialLifecycleState(LifecycleState.RESUMED)
-                .build();
-
-        mReactRootView.startReactApplication(mReactInstanceManager, "example", null);
-
-        setContentView(mReactRootView);
-    }
-
-    ...
+rnpm install react-native-image-resizer
 ```
 
 ## Usage example


### PR DESCRIPTION
I think we can remove the part on manual setup : no one is using it (?) and you have to scroll more to reach the part that interests everyone: example and API. If there are people that still need it, maybe put it in another `.md` or below the example and API parts.

To set up the plugin, you can do `rnpm install <package>` instead of `npm i <package> --save` and `rnpm link <package>`. 