### PR TITLE
bump version to 0.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-image-resizer",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Rescale local images with React Native",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The [sources on npm](https://www.npmjs.com/package/react-native-image-resizer) are outdated, I guess it is linked to the version number of the package (it has not been updated for a month).