### PR TITLE
Getting rid of deprecation warning on iOS

### DIFF
--- a/ios/RCTImageResizer/RCTImageResizer.m
+++ b/ios/RCTImageResizer/RCTImageResizer.m
@@ -50,7 +50,7 @@ RCT_EXPORT_METHOD(createResizedImage:(NSString *)path
     CGSize newSize = CGSizeMake(width, height);
     NSString* fullPath = generateFilePath(@"jpg", outputPath);
 
-    [_bridge.imageLoader loadImageWithTag:path callback:^(NSError *error, UIImage *image) {
+    [_bridge.imageLoader loadImageWithURLRequest:[RCTConvert NSURLRequest:path] callback:^(NSError *error, UIImage *image) {
         if (error || image == nil) {
             if ([path hasPrefix:@"data:"] || [path hasPrefix:@"file:"]) {
                 NSURL *imageUrl = [[NSURL alloc] initWithString:path];


### PR DESCRIPTION
This closes issue #24 