### PR TITLE
Added support for PNG compression for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Option | Description
 path | Path of image
 maxWidth | Image max width (ratio is preserved)
 maxHeight | Image max height (ratio is preserved)
-compressFormat | Can be either JPEG, PNG (android only) or WEBP (android only).
+compressFormat | Can be either JPEG, PNG or WEBP (android only).
 quality | A number between 0 and 100. Used for the JPEG compression.
 rotation | Rotation to apply to the image, in degrees, for android only. On iOS, the resizing is done such that the orientation is always up.
 outputPath | The resized image path. If null, resized image will be stored in cache folder. To set outputPath make sure to add option for rotation too (if no rotation is needed, just set it to 0).

--- a/index.ios.js
+++ b/index.ios.js
@@ -4,12 +4,12 @@ import {
 
 export default {
   createResizedImage: (path, width, height, format, quality, rotation = 0, outputPath) => {
-    if (format !== 'JPEG') {
-      throw new Error('Only JPEG format is supported by createResizedImage');
+    if (format !== 'JPEG' && format !== 'PNG') {
+      throw new Error('Only JPEG and PNG format are supported by createResizedImage');
     }
 
     return new Promise((resolve, reject) => {
-      NativeModules.ImageResizer.createResizedImage(path, width, height, quality, outputPath, (err, resizedPath) => {
+      NativeModules.ImageResizer.createResizedImage(path, width, height, format, quality, outputPath, (err, resizedPath) => {
         if (err) {
           return reject(err);
         }


### PR DESCRIPTION
@bamlab-bot Had to have PNG compression for iOS in order to keep alpha transparency in the resized image. Wasn't very difficult to add. Could you create a new version once you consider this to be mergeable please?