### PR TITLE
Enable the android image resizer to handle base64 formated Uri strings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The promise resolves with a string containing the uri of the new file.
 
 Option | Description
 ------ | -----------
-path | Path of image
+path | Path of image file, or a base64 encoded image string prefixed with 'data:image/<imagetype>' where <imagetype> is jpeg or png.
 maxWidth | Image max width (ratio is preserved)
 maxHeight | Image max height (ratio is preserved)
 compressFormat | Can be either JPEG, PNG or WEBP (android only).

--- a/android/src/main/java/fr/bamlab/rnimageresizer/ImageResizerModule.java
+++ b/android/src/main/java/fr/bamlab/rnimageresizer/ImageResizerModule.java
@@ -45,7 +45,10 @@ class ImageResizerModule extends ReactContextBaseJavaModule {
                                            String compressFormatString, int quality, int rotation, String outputPath,
                                            final Callback successCb, final Callback failureCb) throws IOException {
         Bitmap.CompressFormat compressFormat = Bitmap.CompressFormat.valueOf(compressFormatString);
-        imagePath = imagePath.replace("file:", "");
+        if (imagePath.indexOf("data:image/") < 0) {
+            imagePath = imagePath.replace("file:", "");
+        }
+
         String resizedImagePath = ImageResizer.createResizedImage(this.context, imagePath, newWidth,
                 newHeight, compressFormat, quality, rotation, outputPath);
 


### PR DESCRIPTION
Enable the Android react-native-image-resizer library to handle incoming URI in base64 format.
If the incoming URI is in "file" format, the code that runs is exactly the same as the previous commit.