### PR TITLE
Add note to README explaining `file:` prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ A basic, sample app is available in [the `example` folder](https://github.com/ba
 
 ### `promise createResizedImage(path, maxWidth, maxHeight, compressFormat, quality, rotation = 0, outputPath)`
 
-The promise resolves with a string containing the uri of the new file.
+The promise resolves with a string containing the URI of the new file. This URI can be used directly as the `source` of an [`<Image>`](https://facebook.github.io/react-native/docs/image.html) component.
+
+> :warning: On Android, `file:` will be prepended to the returned string. This allows it to be displayed as an image, but it also means you [won't be able to access the file directly](https://github.com/bamlab/react-native-image-resizer/issues/50) when using a utility like `fs`. To do so, you can simply use `rawPath = originalPath.replace('file:', '')` to get the raw path.
 
 Option | Description
 ------ | -----------


### PR DESCRIPTION
Resolves #50. See the rich diff [here](https://github.com/bamlab/react-native-image-resizer/pull/62/files?short_path=04c6e90).

cc @4ian 