### PR TITLE
Unify returned value between Android and iOS implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,11 @@ Note: on latest versions of React Native, you may have an error during the Gradl
 ```javascript
 import ImageResizer from 'react-native-image-resizer';
 
-ImageResizer.createResizedImage(imageUri, newWidth, newHeight, compressFormat, quality, rotation, outputPath).then((resizedImageUri) => {
-  // resizeImageUri is the URI of the new image that can now be displayed, uploaded...
+ImageResizer.createResizedImage(imageUri, newWidth, newHeight, compressFormat, quality, rotation, outputPath).then((response) => {
+  // response.uri is the URI of the new image that can now be displayed, uploaded...
+  // response.path is the path of the new image
+  // response.name is the name of the new image with the extension
+  // response.size is the size of the new image
 }).catch((err) => {
   // Oops, something went wrong. Check that the filename is correct and
   // inspect err to get more details.
@@ -49,9 +52,7 @@ A basic, sample app is available in [the `example` folder](https://github.com/ba
 
 ### `promise createResizedImage(path, maxWidth, maxHeight, compressFormat, quality, rotation = 0, outputPath)`
 
-The promise resolves with a string containing the URI of the new file. This URI can be used directly as the `source` of an [`<Image>`](https://facebook.github.io/react-native/docs/image.html) component.
-
-> :warning: On Android, `file:` will be prepended to the returned string. This allows it to be displayed as an image, but it also means you [won't be able to access the file directly](https://github.com/bamlab/react-native-image-resizer/issues/50) when using a utility like `fs`. To do so, you can simply use `rawPath = originalPath.replace('file:', '')` to get the raw path.
+The promise resolves with an object containing: path, uri, name and size of the new file. The URI can be used directly as the `source` of an [`<Image>`](https://facebook.github.io/react-native/docs/image.html) component.
 
 Option | Description
 ------ | -----------

--- a/android/src/main/java/fr/bamlab/rnimageresizer/ImageResizerModule.java
+++ b/android/src/main/java/fr/bamlab/rnimageresizer/ImageResizerModule.java
@@ -2,12 +2,16 @@ package fr.bamlab.rnimageresizer;
 
 import android.content.Context;
 import android.graphics.Bitmap;
+import android.net.Uri;
 
+import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.WritableMap;
 
+import java.io.File;
 import java.io.IOException;
 
 /**
@@ -45,19 +49,22 @@ class ImageResizerModule extends ReactContextBaseJavaModule {
                                            String compressFormatString, int quality, int rotation, String outputPath,
                                            final Callback successCb, final Callback failureCb) throws IOException {
         Bitmap.CompressFormat compressFormat = Bitmap.CompressFormat.valueOf(compressFormatString);
-        if (imagePath.startsWith(ImageResizer.FILE_PREFIX)) {
-            imagePath = imagePath.replaceFirst(ImageResizer.FILE_PREFIX, "");
-        }
+        Uri imageUri = Uri.parse(imagePath);
 
-        String resizedImagePath = ImageResizer.createResizedImage(this.context, imagePath, newWidth,
+        File resizedImage = ImageResizer.createResizedImage(this.context, imageUri, newWidth,
                 newHeight, compressFormat, quality, rotation, outputPath);
 
         // If resizedImagePath is empty and this wasn't caught earlier, throw.
-        if (resizedImagePath == null || resizedImagePath.isEmpty()) {
-            throw new IOException("Error getting resized image path");
+        if (resizedImage.isFile()) {
+            WritableMap response = Arguments.createMap();
+            response.putString("path", resizedImage.getAbsolutePath());
+            response.putString("uri", Uri.fromFile(resizedImage).toString());
+            response.putString("name", resizedImage.getName());
+            response.putDouble("size", resizedImage.length());
+            // Invoke success
+            successCb.invoke(response);
+        } else {
+            failureCb.invoke("Error getting resized image path");
         }
-
-        // Invoke success, prepending file prefix.
-        successCb.invoke(ImageResizer.FILE_PREFIX + resizedImagePath);
     }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,13 @@
 declare module "react-native-image-resizer" {
+    export interface Response {
+        path: string;
+        uri: string;
+        size?: number;
+        name?: string;
+    }
     export function createResizedImage(
         uri: string, width: number, height: number,
         format: "PNG" | "JPEG" | "WEBP", quality: number,
         rotation?: number, outputPath?: string
-    ): Promise<string>;
+    ): Promise<Response>;
 }

--- a/index.ios.js
+++ b/index.ios.js
@@ -9,12 +9,12 @@ export default {
     }
 
     return new Promise((resolve, reject) => {
-      NativeModules.ImageResizer.createResizedImage(path, width, height, format, quality, rotation, outputPath, (err, resizedPath) => {
+      NativeModules.ImageResizer.createResizedImage(path, width, height, format, quality, rotation, outputPath, (err, response) => {
         if (err) {
           return reject(err);
         }
 
-        resolve(resizedPath);
+        resolve(response);
       });
     });
   },

--- a/ios/RCTImageResizer/RCTImageResizer.m
+++ b/ios/RCTImageResizer/RCTImageResizer.m
@@ -131,8 +131,18 @@ RCT_EXPORT_METHOD(createResizedImage:(NSString *)path
             callback(@[@"Can't save the image. Check your compression format.", @""]);
             return;
         }
+        NSURL *fileUrl = [[NSURL alloc] initFileURLWithPath:fullPath];
+        NSString *fileName = fileUrl.lastPathComponent;
+        NSError *attributesError = nil;
+        NSDictionary *fileAttributes = [[NSFileManager defaultManager] attributesOfItemAtPath:fullPath error:&attributesError];
+        NSNumber *fileSize = fileAttributes == nil ? 0 : [fileAttributes objectForKey:NSFileSize];
+        NSDictionary *response = @{@"path": fullPath,
+                                   @"uri": fileUrl.absoluteString,
+                                   @"name": fileName,
+                                   @"size": fileSize == nil ? 0 : fileSize
+                                   };
         
-        callback(@[[NSNull null], fullPath]);
+        callback(@[[NSNull null], response]);
     }];
 }
 


### PR DESCRIPTION
Previously Android implementation worked differently and to the returned
absolute path a 'file:' is prepended.

This different behaviour may causes issues/bugs when handling the response from an
unified code base point of view and also the returned uri on the Android native code
is not generated properly using native functions to do so.

This patch fixes this incoherence, but also extends the returned value to add:
absolute path, file name, file size and the uri.
Refactored Android code to make it easier to read and more robust to
case sensitive file names.