### PR TITLE
Remove deprecated method for RN 0.47 compat

### DIFF
--- a/android/src/main/java/fr/bamlab/rnimageresizer/ImageResizerPackage.java
+++ b/android/src/main/java/fr/bamlab/rnimageresizer/ImageResizerPackage.java
@@ -27,18 +27,6 @@ public class ImageResizerPackage implements ReactPackage {
     }
 
     /**
-     * @return list of JS modules to register with the newly created catalyst instance.
-     * <p/>
-     * IMPORTANT: Note that only modules that needs to be accessible from the native code should be
-     * listed here. Also listing a native module here doesn't imply that the JS implementation of it
-     * will be automatically included in the JS bundle.
-     */
-    @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
-    /**
      * @param reactContext
      * @return a list of view managers that should be registered with {@link UIManagerModule}
      */


### PR DESCRIPTION
The component doesn't compile in RN 0.47-rc5 - discussion at https://github.com/facebook/react-native/issues/15232