### PR TITLE
[Dependencies] Support react 16 with react-native 0.47+

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "resize"
   ],
   "peerDependencies": {
-    "react": "^15.4.0",
+    "react": ">=15.4.0",
     "react-native": ">=v0.40.0"
   },
   "author": "Florian Rival <florianr@bam.tech> (http://bam.tech)",


### PR DESCRIPTION
Hi there, thanks for creating this package! Right now we're getting a warning when using this on react-native 0.47 since it requires react 16.0.0-alpha.12. This updates the peerDependencies to support anything greater than 15.4.0. If you instead want an `or` condition such as: `^15.4.0 || ^16.0.0`, let me know and I can make that change. Thanks!

```
warning "react-native-image-resizer@0.1.1" has incorrect peer dependency "react@^15.4.0".
```