### PR TITLE
Fix rotate exception caused by Bitmap.createBitmap

### DIFF
--- a/android/src/main/java/fr/bamlab/rnimageresizer/ImageResizer.java
+++ b/android/src/main/java/fr/bamlab/rnimageresizer/ImageResizer.java
@@ -279,14 +279,16 @@ class ImageResizer {
             sourceImage.recycle();
         }
 
-        // Rotate if necessary
         Bitmap rotatedImage = scaledImage;
-        int orientation = getOrientation(context, imageUri);
-        rotation = orientation + rotation;
-        rotatedImage = ImageResizer.rotateImage(scaledImage, rotation);
+        // Rotate if necessary
+        if (rotation != 0) {
+          int orientation = getOrientation(context, imageUri);
+          rotation = orientation + rotation;
+          rotatedImage = ImageResizer.rotateImage(scaledImage, rotation);
 
-        if (scaledImage != rotatedImage) {
-            scaledImage.recycle();
+          if (scaledImage != rotatedImage) {
+              scaledImage.recycle();
+          }
         }
 
         // Save the resulting image


### PR DESCRIPTION
- Ocassionally, "Could not invoke ImageResizerAndroid.createResizedImage"
exception is thrown, and it's caused by `ImageResizer.rotateImage` which
calls `Bitmap.createBitmap`. The reason why this exception is thrown is
still unknown. source.getWidth() and source.getHeight() properly returns
an correct int, might be due to `source` not compatible with
`Bitmap.createBitmap`.
- We can go around this by skipping `ImageResizer.rotateImage` if rotation
is 0.