### PR TITLE
[Dependencies] Update react peerDependency semver range to support 16-alpha + beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "resize"
   ],
   "peerDependencies": {
-    "react": ">=15.4.0",
+    "react": "^15.4.0 || ^16.0.0-alpha",
     "react-native": ">=v0.40.0"
   },
   "author": "Florian Rival <florianr@bam.tech> (http://bam.tech)",


### PR DESCRIPTION
My apologies, the previous PR (#96) I provided and was merged :/ did not fully fix the peer dependency issue. This PR updates the range to support 15 + 16-alpha and 16-beta. I tested the change using https://semver.npmjs.com/ to verify it would catch all current alpha and beta versions of react.

Sorry for the duplicated PRs!