### PR TITLE
Use RCTBridgeModule.h instead of RCTBridge.h

### DIFF
--- a/ios/RCTImageResizer/RCTImageResizer.h
+++ b/ios/RCTImageResizer/RCTImageResizer.h
@@ -1,4 +1,4 @@
-#import <React/RCTBridge.h>
+#import <React/RCTBridgeModule.h>
 
 @interface ImageResizer : NSObject <RCTBridgeModule>
 


### PR DESCRIPTION
Looks like `RCTBridge.h` got deprecated and official docs use `#import <React/RCTBridgeModule.h>` form anyway. This also makes this lib usable under (at least) RN 0.48.

Docs reference: http://facebook.github.io/react-native/releases/0.48/docs/native-modules-ios.html#ios-calendar-module-example