### PR TITLE
fix error: ImageResizer is not public

### DIFF
--- a/android/src/main/java/fr/bamlab/rnimageresizer/ImageResizer.java
+++ b/android/src/main/java/fr/bamlab/rnimageresizer/ImageResizer.java
@@ -21,7 +21,7 @@ import java.util.Date;
 /**
  * Provide methods to resize and rotate an image file.
  */
-class ImageResizer {
+public class ImageResizer {
     private final static String IMAGE_JPEG = "image/jpeg";
     private final static String IMAGE_PNG = "image/png";
     private final static String SCHEME_DATA = "data";


### PR DESCRIPTION
When call a function of ImageResizer directly in some situation in android, got the error and can't complile as ImageResizer class isn't exposed to public.

Error detail:
error: ImageResizer is not public in fr.bamlab.rnimageresizer; cannot be accessed from outside package 618 import fr.bamlab.rnimageresizer.ImageResizer;