### PR TITLE
react-native-image-resizer@0.1.1 compatible with react-native 0.47+

### DIFF
--- a/android/src/main/java/fr/bamlab/rnimageresizer/ImageResizerPackage.java
+++ b/android/src/main/java/fr/bamlab/rnimageresizer/ImageResizerPackage.java
@@ -33,7 +33,7 @@ public class ImageResizerPackage implements ReactPackage {
      * listed here. Also listing a native module here doesn't imply that the JS implementation of it
      * will be automatically included in the JS bundle.
      */
-    @Override
+    // Deprecated from RN 0.47.0
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Hi there! Made a little fix, but this was really anoying for me (was using 0.1.1 but needed to update RN asap). Would be great if you'll merge it to 0.1.1, so i'll be able to use your repo 0.1.1 for newer version of RN. Thank you!