### PR TITLE
Fixed exception when specified outputPath 

### DIFF
--- a/android/src/main/java/fr/bamlab/rnimageresizer/ImageResizer.java
+++ b/android/src/main/java/fr/bamlab/rnimageresizer/ImageResizer.java
@@ -83,6 +83,7 @@ public class ImageResizer {
         }
 
         File newFile = new File(saveDirectory, fileName + "." + compressFormat.name());
+        newFile.getParentFile().mkdirs();
         if(!newFile.createNewFile()) {
             throw new IOException("The file already exists");
         }


### PR DESCRIPTION
When specified outputPath within directory that doesn't exist we received exception.
I've added creating parent directories before creating new file