### PR TITLE
fix(ios): `outputPath` on iOS can contain an absolute path

### DIFF
--- a/ios/RCTImageResizer/RCTImageResizer.m
+++ b/ios/RCTImageResizer/RCTImageResizer.m
@@ -42,7 +42,12 @@ NSString * generateFilePath(NSString * ext, NSString * outputPath)
     } else {
         NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
         NSString *documentsDirectory = [paths objectAtIndex:0];
-        directory = [documentsDirectory stringByAppendingPathComponent:outputPath];
+        if ([outputPath hasPrefix:documentsDirectory]) {
+            directory = outputPath;
+        } else {
+            directory = [documentsDirectory stringByAppendingPathComponent:outputPath];
+        }
+        
         NSError *error;
         [[NSFileManager defaultManager] createDirectoryAtPath:directory withIntermediateDirectories:YES attributes:nil error:&error];
         if (error) {


### PR DESCRIPTION
Closes #107

This PR rebase work done by @ulentini years ago preserving author and date information.

I change the commit name to match commitizen convention.