### PR TITLE
Remove buildscript block from build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,14 +1,3 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
-    }
-}
-
 apply plugin: 'com.android.library'
 
 android {


### PR DESCRIPTION
In order for project-wide repositories settings to take effect for this module, the module should not need to define a buildscript block unless there is something extra special to take care of. 

This helps out when you run an internal mirror of maven (or a proxy such as nexus) to speed up downloading dependencies. 

If there's a better way of doing this, please let me know. 