### PR TITLE
fix: support customizing of android tools versions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,19 +1,41 @@
-apply plugin: 'com.android.library'
+buildscript {
+    repositories {
+        jcenter()
+    }
 
-def safeExtGet(prop, fallback) {
-    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+
+    dependencies {
+        classpath 'com.android.tools.build:gradle:2.2.3'
+    }
 }
 
+apply plugin: 'com.android.library'
+def _ext = rootProject.ext;
+
+def _compileSdkVersion = _ext.has('compileSdkVersion') ? _ext.compileSdkVersion : 25;
+def _buildToolsVersion = _ext.has('buildToolsVersion') ? _ext.buildToolsVersion : '25.0.2';
+def _minSdkVersion = _ext.has('minSdkVersion') ? _ext.minSdkVersion : 16;
+def _targetSdkVersion = _ext.has('targetSdkVersion') ? _ext.targetSdkVersion : 25;
+
 android {
-    compileSdkVersion safeExtGet('compileSdkVersion', 26)
-    buildToolsVersion safeExtGet('buildToolsVersion', "26.0.3")
+    compileSdkVersion _compileSdkVersion
+    buildToolsVersion _buildToolsVersion
 
     defaultConfig {
-        minSdkVersion safeExtGet('minSdkVersion', 16)
-        targetSdkVersion safeExtGet('targetSdkVersion', 26)
+        minSdkVersion _minSdkVersion
+        targetSdkVersion _targetSdkVersion
         versionCode 1
         versionName "1.0"
     }
+    buildTypes {
+        release {
+            minifyEnabled false
+        }
+    }
+}
+
+repositories {
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
This commit fixes some errors that may occur if compileSdkVersion on base project is different from the version (that is hardcoded) on `android/build.gradle` of this package