### PR TITLE
Do not crash during rotation on some devices

### DIFF
--- a/android/src/main/java/fr/bamlab/rnimageresizer/ImageResizer.java
+++ b/android/src/main/java/fr/bamlab/rnimageresizer/ImageResizer.java
@@ -65,7 +65,11 @@ public class ImageResizer {
         Matrix matrix = new Matrix();
         matrix.postRotate(angle);
         try {
-            retVal = Bitmap.createBitmap(source, 0, 0, source.getWidth(), source.getHeight(), matrix, true);
+            if (source != null) {
+              retVal = Bitmap.createBitmap(source, 0, 0, source.getWidth(), source.getHeight(), matrix, true);
+            } else {
+              retVal = null;
+            }
         } catch (OutOfMemoryError e) {
             return null;
         }


### PR DESCRIPTION
I don't know why, but on some devices is sometimes source null, escpecially on my old Samsung with Android 7. This is not fix, but it will prevent to crash whole app, it will only reject promise. Maybe it will be useful for someone.

Related to #53 