### PR TITLE
Updated the `generateFilePath()`

### DIFF
--- a/ios/RCTImageResizer/RCTImageResizer.m
+++ b/ios/RCTImageResizer/RCTImageResizer.m
@@ -35,14 +35,17 @@ bool saveImage(NSString * fullPath, UIImage * image, NSString * format, float qu
 NSString * generateFilePath(NSString * ext, NSString * outputPath)
 {
     NSString* directory;
+    NSArray *documentsPaths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
 
     if ([outputPath length] == 0) {
-        NSArray* paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
-        directory = [paths firstObject];
+        directory = [documentsPaths firstObject];
     } else {
-        NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
-        NSString *documentsDirectory = [paths objectAtIndex:0];
-        if ([outputPath hasPrefix:documentsDirectory]) {
+        NSString *documentsDirectory = [documentsPaths firstObject];
+
+        NSArray *cachePaths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
+        NSString *cacheDirectory = [cachePaths firstObject];
+
+        if ([outputPath hasPrefix:documentsDirectory] || [outputPath hasPrefix:cacheDirectory]) {
             directory = outputPath;
         } else {
             directory = [documentsDirectory stringByAppendingPathComponent:outputPath];


### PR DESCRIPTION
Updated the `generateFilePath()` method to accept paths on cache directory. It also generate new files on documents directory, to be consistent with the rest of the method behavior.

Discussion: #90 