### PR TITLE
fix ios build, RCTImageLoader

### DIFF
--- a/ios/RCTImageResizer/RCTImageResizer.m
+++ b/ios/RCTImageResizer/RCTImageResizer.m
@@ -6,7 +6,7 @@
 //
 
 #include "RCTImageResizer.h"
-#import <React/RCTImageLoader.h>
+#import <React/RCTImageLoaderProtocol.h>
 #import <AssetsLibrary/AssetsLibrary.h>
 #import <MobileCoreServices/MobileCoreServices.h>
 
@@ -361,7 +361,7 @@ RCT_EXPORT_METHOD(createResizedImage:(NSString *)path
         }
 
 
-        [[_bridge moduleForClass:[RCTImageLoader class]] loadImageWithURLRequest:[RCTConvert NSURLRequest:path] callback:^(NSError *error, UIImage *image) {
+        [[_bridge moduleForName:@"ImageLoader" lazilyLoadIfNecessary:YES] loadImageWithURLRequest:[RCTConvert NSURLRequest:path] callback:^(NSError *error, UIImage *image) {
             if (error) {
                 callback(@[@"Can't retrieve the file from the path.", @""]);
                 return;


### PR DESCRIPTION
I got issue once I build IOS
`Undefined symbol: _OBJC_Class_$_RCTImageLoader.` related to `RCTImageLoader` in `RCTImageResizer.m`

I got references from other react-native liblary https://github.com/react-native-community/react-native-cameraroll/pull/109