### PR TITLE
fix: prevent compile errors

### DIFF
--- a/ios/RCTImageResizer/RCTImageResizer.m
+++ b/ios/RCTImageResizer/RCTImageResizer.m
@@ -6,7 +6,17 @@
 //
 
 #include "RCTImageResizer.h"
+
+#if __has_include(<React/RCTBridgeModule.h>)
+#import <React/RCTBridgeModule.h>
 #import <React/RCTImageLoader.h>
+#import <React/RCTImageURLLoader.h>
+#else
+#import "RCTBridgeModule.h"
+#import "RCTImageLoader.h"
+#import "RCTImageURLLoader.h"
+#endif
+
 #import <AssetsLibrary/AssetsLibrary.h>
 #import <MobileCoreServices/MobileCoreServices.h>
 
@@ -361,7 +371,7 @@ RCT_EXPORT_METHOD(createResizedImage:(NSString *)path
         }
 
 
-        [[_bridge moduleForClass:[RCTImageLoader class]] loadImageWithURLRequest:[RCTConvert NSURLRequest:path] callback:^(NSError *error, UIImage *image) {
+        [[self.bridge moduleForName:@"ImageLoader" lazilyLoadIfNecessary:YES] loadImageWithURLRequest:[RCTConvert NSURLRequest:path] callback:^(NSError *error, UIImage *image) {
             if (error) {
                 callback(@[@"Can't retrieve the file from the path.", @""]);
                 return;


### PR DESCRIPTION
This PR prevents compile errors on iOS
It's a copy paste from this pr https://github.com/bamlab/react-native-image-resizer/pull/211 without merge conflicts