### PR TITLE
fix: compile errors on ios

### DIFF
--- a/ios/RCTImageResizer/RCTImageResizer.m
+++ b/ios/RCTImageResizer/RCTImageResizer.m
@@ -10,11 +10,9 @@
 #if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
 #import <React/RCTImageLoader.h>
-#import <React/RCTImageURLLoader.h>
 #else
 #import "RCTBridgeModule.h"
 #import "RCTImageLoader.h"
-#import "RCTImageURLLoader.h"
 #endif
 
 #import <AssetsLibrary/AssetsLibrary.h>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-image-resizer",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Rescale local images with React Native",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Removing (unused?) ImageUrlLoader which doesn't exist in old react-native versions.
