### PR TITLE
fix typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,8 +2,8 @@ declare module 'react-native-image-resizer' {
   export interface Response {
     path: string;
     uri: string;
-    size?: number;
-    name?: string;
+    size: number;
+    name: string;
     width: number;
     height: number;
   }

--- a/index.js.flow
+++ b/index.js.flow
@@ -2,10 +2,10 @@
 declare type ResizedImageInfo = {
   path: string,
   uri: string,
-  size?: number,
-  name?: string,
+  size: number,
+  name: string,
   height: number,
-  width: number
+  width: number,
 };
 
 declare function createResizedImage(
@@ -20,5 +20,5 @@ declare function createResizedImage(
 ): Promise<ResizedImageInfo>;
 
 declare export default {
-  createResizedImage: createResizedImage,
+  createResizedImage: typeof createResizedImage,
 };


### PR DESCRIPTION
this fixes 2 things:

1) flow error:

```
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ node_modules/react-native-image-resizer/index.js.flow:23:23

Cannot use createResizedImage as a type. A name can be used as a type only if it refers to a type definition, an
interface definition, or a class definition. To get the type of a non-class value, use typeof.

     20│ ): Promise<ResizedImageInfo>;
     21│
     22│ declare export default {
     23│   createResizedImage: createResizedImage,
     24│ };
     25│
```

following the given advice works 

2) `size` and `name`, from what I can tell, are always present in the success response so they should be marked as such

see https://github.com/bamlab/react-native-image-resizer/blob/54dce2add754588d04dea826e150f60623a81b90/ios/RCTImageResizer/RCTImageResizer.m#L333

and

https://github.com/bamlab/react-native-image-resizer/blob/54dce2add754588d04dea826e150f60623a81b90/android/src/main/java/fr/bamlab/rnimageresizer/ImageResizerModule.java#L86