### PR TITLE
Fixed the image loading for share extensions

### DIFF
--- a/ios/RCTImageResizer/RCTImageResizer.m
+++ b/ios/RCTImageResizer/RCTImageResizer.m
@@ -368,8 +368,16 @@ RCT_EXPORT_METHOD(createResizedImage:(NSString *)path
             return;
         }
 
-
-        [[self.bridge moduleForName:@"ImageLoader" lazilyLoadIfNecessary:YES] loadImageWithURLRequest:[RCTConvert NSURLRequest:path] callback:^(NSError *error, UIImage *image) {
+        RCTImageLoader *loader = [self.bridge moduleForName:@"ImageLoader" lazilyLoadIfNecessary:YES];
+        NSURLRequest *request = [RCTConvert NSURLRequest:path];
+        [loader loadImageWithURLRequest:request
+                                   size:newSize
+                                  scale:1
+                                clipped:YES
+                             resizeMode:RCTResizeModeStretch
+                          progressBlock:nil
+                       partialLoadBlock:nil
+                        completionBlock:^(NSError *error, UIImage *image) {
             if (error) {
                 callback(@[@"Can't retrieve the file from the path.", @""]);
                 return;


### PR DESCRIPTION
Replaced the loading method with its call to a lower method that passes in the same values, with the exception being we are passing in the target size width and height being passed down from higher up in the JS layer. 

In the previous implementation it was sending a `CGSizeZero` for the target size down to the Image loader method, which when going through the React_ImageLoader, would load the whole image at full size. An image would be compressed when its was loaded from the Data. 

Take for example a picture from the phone camera roll. It would be, for example, 4032 X 3024 pixels. When the image is being loaded by the react native library for rendering an image, it is passing in a target size for example of 120 X 120. The underlying react native image loader code will create a smaller image of the specified size, determining to scale it right it needs to be 160 X 160, to match the target limit. It will use the image scale to determine pixel size and create a in memory bitmap 320 x 240, and put that into an UIImage, returning that from the library, so it could be rendered on the screen. It is not showing a full image, but rather the resized image at that size, which works.

By sending CGSizeZero when we are calling the top level method, it hits a conditional deeper in that method that is doing the image introspection and resizing to the target size, and making the target size the size of the source, which is large. 
Handling the data is ok since the data is compressed, and had the library just returned the original compressed data the image would have loaded fine, but since its not, it trys to resized it. so it makes an new CGImage the the full size of the image uncompressed., and returns that UIImage of the new CGImage. So a 2.8 MB image balloons to a much higher memory usage. Under normal circumstances, this is harmless in a regular application, since we can easily jump 30 MB, but in a share extension using react native there is a limit of 120 MB, with react native taking up at least 60 MB or so, so a 30 MB jump can cause the extension to fail, if there is any more memory usage that expected.

Since we know from what has been passed in, what size we want the image to be already, we can just pass in that size directly before the transform, so rather than loading the whole image in the underlying library, we load the image already shrunk. It will still increase the memory, but a lot less than we would have with the CGSizeZero. By specifying a limit of the size in the higher code we can ensure the functionality in the app extension.