### PR TITLE
Fix resize image for share extension maintaining aspect ratio of passed size

### DIFF
--- a/ios/RCTImageResizer/RCTImageResizer.m
+++ b/ios/RCTImageResizer/RCTImageResizer.m
@@ -368,8 +368,16 @@ RCT_EXPORT_METHOD(createResizedImage:(NSString *)path
             return;
         }
 
-
-        [[self.bridge moduleForName:@"ImageLoader" lazilyLoadIfNecessary:YES] loadImageWithURLRequest:[RCTConvert NSURLRequest:path] callback:^(NSError *error, UIImage *image) {
+        RCTImageLoader *loader = [self.bridge moduleForName:@"ImageLoader" lazilyLoadIfNecessary:YES];
+        NSURLRequest *request = [RCTConvert NSURLRequest:path];
+        [loader loadImageWithURLRequest:request
+                                   size:newSize
+                                  scale:1
+                                clipped:NO
+                             resizeMode:RCTResizeModeContain
+                          progressBlock:nil
+                       partialLoadBlock:nil
+                        completionBlock:^(NSError *error, UIImage *image) {
             if (error) {
                 callback(@[@"Can't retrieve the file from the path.", @""]);
                 return;


### PR DESCRIPTION
in reference to the issues discussed in:

https://github.com/bamlab/react-native-image-resizer/issues/250

This implements setting the resized mode to be a `FIT` rather than a `FILL` with NO clipping so the original data maintains its aspect ration while its being loaded, and then can be transformed by the library, while still reducing the raw image size in memory.