### PR TITLE
fix: change pod dependency

### DIFF
--- a/react-native-image-resizer.podspec
+++ b/react-native-image-resizer.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.preserve_paths = 'README.md', 'LICENSE', 'package.json', 'index.js'
   s.source_files   = "ios/RCTImageResizer/*.{h,m}"
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
 end


### PR DESCRIPTION
After XCode 12 release, the previous implementation was breaking. See https://github.com/facebook/react-native/issues/29633#issuecomment-694187116