### PR TITLE
update podspec file to include `React-RCTImage` as a dependency

### DIFF
--- a/react-native-image-resizer.podspec
+++ b/react-native-image-resizer.podspec
@@ -17,4 +17,5 @@ Pod::Spec.new do |s|
   s.source_files   = "ios/RCTImageResizer/*.{h,m}"
 
   s.dependency 'React-Core'
+  s.dependency 'React-RCTImage'
 end


### PR DESCRIPTION
With the 1.3.0 update, I've been running into issue during my xCode iOS build process where it will say `'React/RCTImageLoader.h' file not found`. I'm running

```
react: 16.8.6
react-native: 0.60.6
react-native-image-resizer: 1.3.0
```

Found some advice here https://github.com/unimodules/react-native-unimodules/issues/97#issuecomment-637180616 and it seems like doing so will fix the issue.