### PR TITLE
Fix:[iOS] Resize mode cover doesn't match RN Image cover

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -13,7 +13,7 @@ import {
   Alert,
   TouchableOpacity,
   PermissionsAndroid,
-  Platform
+  Platform,
 } from 'react-native';
 import RNPickerSelect from 'react-native-picker-select';
 import CameraRoll from '@react-native-community/cameraroll';
@@ -56,21 +56,23 @@ const styles = StyleSheet.create({
     padding: 5,
     width: '50%',
     borderColor: 'gray',
-    borderWidth: 1 ,
+    borderWidth: 1,
   },
 });
 
-const modeOptions = ['contain', 'cover', 'stretch'].map(
-  mode => ({ label: mode, value: mode })
-);
+const modeOptions = ['contain', 'cover', 'stretch'].map((mode) => ({
+  label: mode,
+  value: mode,
+}));
 
-const onlyScaleDownOptions = [false, true].map(
-  onlyScaleDown => ({ label: onlyScaleDown.toString(), value: onlyScaleDown })
-);
+const onlyScaleDownOptions = [false, true].map((onlyScaleDown) => ({
+  label: onlyScaleDown.toString(),
+  value: onlyScaleDown,
+}));
 
 const targetSizeOptions = [
-  { label: '80x80', value: 80 },
-  { label: '5000x5000', value: 5000 },
+  {label: '80x80', value: 80},
+  {label: '5000x5000', value: 5000},
 ];
 
 export default class ResizerExample extends Component {
@@ -89,74 +91,88 @@ export default class ResizerExample extends Component {
   }
 
   async componentDidMount() {
-    let isAllowedToAccessPhotosOnAndroid = false
-    if (Platform.OS === "android") {
-      isAllowedToAccessPhotosOnAndroid = await this.hasAndroidPermission()
-
+    let isAllowedToAccessPhotosOnAndroid = false;
+    if (Platform.OS === 'android') {
+      isAllowedToAccessPhotosOnAndroid = await this.hasAndroidPermission();
     }
-    if (Platform.OS === "ios" || isAllowedToAccessPhotosOnAndroid){
-    CameraRoll.getPhotos({first: 1})
-      .then(photos => {
-        if (!photos.edges || photos.edges.length === 0) {
+    if (Platform.OS === 'ios' || isAllowedToAccessPhotosOnAndroid) {
+      CameraRoll.getPhotos({first: 1})
+        .then((photos) => {
+          if (!photos.edges || photos.edges.length === 0) {
+            return Alert.alert(
+              'Unable to load camera roll',
+              'Check that you authorized the access to the camera roll photos and that there is at least one photo in it',
+            );
+          }
+
+          this.setState({
+            image: photos.edges[0].node.image,
+          });
+        })
+        .catch(() => {
           return Alert.alert(
             'Unable to load camera roll',
-            'Check that you authorized the access to the camera roll photos and that there is at least one photo in it',
+            'Check that you authorized the access to the camera roll photos',
           );
-        }
-
-        this.setState({
-          image: photos.edges[0].node.image,
         });
-      })
-      .catch(() => {
-        return Alert.alert(
-          'Unable to load camera roll',
-          'Check that you authorized the access to the camera roll photos',
-        );
-      });
-  }
-}
-
-hasAndroidPermission = async ()=> {
-  const permission = PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE;
-
-  const hasPermission = await PermissionsAndroid.check(permission);
-  if (hasPermission) {
-    return true;
+    }
   }
 
-  const status = await PermissionsAndroid.request(permission);
-  return status === 'granted';
-}
+  hasAndroidPermission = async () => {
+    const permission = PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE;
+
+    const hasPermission = await PermissionsAndroid.check(permission);
+    if (hasPermission) {
+      return true;
+    }
+
+    const status = await PermissionsAndroid.request(permission);
+    return status === 'granted';
+  };
 
   resize = () => {
-    const { mode, onlyScaleDown, resizeTargetSize } = this.state;
+    const {mode, onlyScaleDown, resizeTargetSize} = this.state;
 
-    this.setState({ resizedImage: null });
+    this.setState({resizedImage: null});
 
-    ImageResizer.createResizedImage(this.state.image.uri, resizeTargetSize, resizeTargetSize, 'JPEG', 100, 0, undefined, false, { mode, onlyScaleDown })
-      .then(resizedImage => {
-        this.setState({ resizedImage });
+    ImageResizer.createResizedImage(
+      this.state.image.uri,
+      resizeTargetSize,
+      resizeTargetSize,
+      'JPEG',
+      100,
+      0,
+      undefined,
+      false,
+      {mode, onlyScaleDown},
+    )
+      .then((resizedImage) => {
+        this.setState({resizedImage});
       })
-      .catch(err => {
+      .catch((err) => {
         console.log(err);
         return Alert.alert(
           'Unable to resize the photo',
           'Check the console for full the error message',
         );
       });
-    }
-  
+  };
 
   render() {
-    const { resizedImage } = this.state;
+    const {resizedImage} = this.state;
 
     return (
-      <ScrollView style={styles.scrollView} contentContainerStyle={styles.container}>
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={styles.container}>
         <Text style={styles.welcome}>Image Resizer example</Text>
         <Text style={styles.instructions}>This is the original image:</Text>
         {this.state.image ? (
-          <Image style={styles.image} source={{uri: this.state.image.uri}} resizeMode="contain" />
+          <Image
+            style={styles.image}
+            source={{uri: this.state.image.uri}}
+            resizeMode={this.state.mode}
+          />
         ) : null}
         <Text style={styles.instructions}>Resized image:</Text>
 
@@ -165,9 +181,9 @@ hasAndroidPermission = async ()=> {
 
           <RNPickerSelect
             value={this.state.mode}
-            onValueChange={(mode) => this.setState({ mode })}
+            onValueChange={(mode) => this.setState({mode})}
             items={modeOptions}
-            style={{ viewContainer: styles.pickerView }}
+            style={{viewContainer: styles.pickerView}}
           />
         </View>
 
@@ -176,9 +192,9 @@ hasAndroidPermission = async ()=> {
 
           <RNPickerSelect
             value={this.state.onlyScaleDown}
-            onValueChange={(onlyScaleDown) => this.setState({ onlyScaleDown })}
+            onValueChange={(onlyScaleDown) => this.setState({onlyScaleDown})}
             items={onlyScaleDownOptions}
-            style={{ viewContainer: styles.pickerView }}
+            style={{viewContainer: styles.pickerView}}
           />
         </View>
 
@@ -187,9 +203,11 @@ hasAndroidPermission = async ()=> {
 
           <RNPickerSelect
             value={this.state.resizeTargetSize}
-            onValueChange={(resizeTargetSize) => this.setState({ resizeTargetSize })}
+            onValueChange={(resizeTargetSize) =>
+              this.setState({resizeTargetSize})
+            }
             items={targetSizeOptions}
-            style={{ viewContainer: styles.pickerView }}
+            style={{viewContainer: styles.pickerView}}
           />
         </View>
 
@@ -202,7 +220,7 @@ hasAndroidPermission = async ()=> {
             <Image
               style={styles.image}
               source={{uri: resizedImage.uri}}
-              resizeMode="contain"
+              resizeMode={this.state.mode}
             />
             <Text>Width: {resizedImage.width}</Text>
             <Text>Height: {resizedImage.height}</Text>

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -238,7 +238,7 @@ PODS:
   - React-jsinspector (0.63.3)
   - react-native-cameraroll (4.0.1):
     - React
-  - react-native-image-resizer (1.3.0):
+  - react-native-image-resizer (1.4.1):
     - React-Core
   - React-RCTActionSheet (0.63.3):
     - React-Core/RCTActionSheetHeaders (= 0.63.3)
@@ -455,8 +455,8 @@ SPEC CHECKSUMS:
   React-jsi: df07aa95b39c5be3e41199921509bfa929ed2b9d
   React-jsiexecutor: b56c03e61c0dd5f5801255f2160a815f4a53d451
   React-jsinspector: 8e68ffbfe23880d3ee9bafa8be2777f60b25cbe2
-  react-native-cameraroll: 60ba0068826eab1c8d43146191bafd4363ea58a7
-  react-native-image-resizer: a79bcffdef1b52160ff91db0d6fa24816a4ff332
+  react-native-cameraroll: 9d2b7c1707204d2040d2812f960c6cebdbd9f670
+  react-native-image-resizer: 354b09df56858289f386dfbd804e318155c14c8f
   React-RCTActionSheet: 53ea72699698b0b47a6421cb1c8b4ab215a774aa
   React-RCTAnimation: 1befece0b5183c22ae01b966f5583f42e69a83c2
   React-RCTBlob: 0b284339cbe4b15705a05e2313a51c6d8b51fa40
@@ -472,4 +472,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 893b3f5aa841eb3409bcefa30c3ddc9e1dc48230
 
-COCOAPODS: 1.9.3
+COCOAPODS: 1.10.0

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   },
   "homepage": "https://github.com/bamlab/react-native-image-resizer#readme",
   "devDependencies": {
-    "cz-conventional-changelog": "^1.2.0"
+    "cz-conventional-changelog": "^1.2.0",
+    "prettier": "2.2.1"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
Resize mode cover should crop the image in order to fit it in the given size.

Before:
![Simulator Screen Shot - iPhone X - 2020-11-30 at 13 06 48](https://user-images.githubusercontent.com/26821326/100610005-3b754800-330f-11eb-9aa9-9db602c2733b.png)

After:
![Simulator Screen Shot - iPhone X - 2020-11-30 at 13 17 02](https://user-images.githubusercontent.com/26821326/100610034-45974680-330f-11eb-884a-c88ce02c18a2.png)
