### PR TITLE
Upgrade exifinterface

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,5 +18,5 @@ android {
 
 dependencies {
     compileOnly "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-    implementation 'androidx.exifinterface:exifinterface:1.1.0-rc01'
+    implementation "androidx.exifinterface:exifinterface:1.3.2"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-image-resizer",
-  "version": "1.4.1",
+  "version": "1.4.3",
   "description": "Rescale local images with React Native",
   "main": "./index.js",
   "types": "./index.d.ts",


### PR DESCRIPTION
Upgrading Exifinterface from 1.1.0 to 1.3.2. No breaking changes expected, but just some overflow and memleaks fixes according to the logs (https://developer.android.com/jetpack/androidx/releases/exifinterface#1.1.0-rc01).

This is an attempt to fix some android devices corrupting images due to exif bugs.