### PR TITLE
Android: get EXIF orientation from content:// URI on r24+ (#86)

### DIFF
--- a/android/src/main/java/com/reactnativeimageresizer/ImageResizer.java
+++ b/android/src/main/java/com/reactnativeimageresizer/ImageResizer.java
@@ -8,6 +8,7 @@ import android.graphics.BitmapFactory;
 import android.graphics.Matrix;
 import androidx.exifinterface.media.ExifInterface;
 import android.net.Uri;
+import android.os.Build;
 import android.provider.MediaStore;
 import android.util.Base64;
 import android.util.Log;
@@ -317,6 +318,12 @@ public class ImageResizer {
    */
   public static int getOrientation(Context context, Uri uri) {
     try {
+      // ExifInterface(InputStream) only exists since Android N (r24)
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+        InputStream input = context.getContentResolver().openInputStream(uri);
+        ExifInterface ei = new ExifInterface(input);
+        return getOrientation(ei);
+      }
       File file = getFileFromUri(context, uri);
       if (file.exists()) {
         ExifInterface ei = new ExifInterface(file.getAbsolutePath());


### PR DESCRIPTION
Android has restricted access to the file:// URIs underlying a shared
content URI a while ago. I'm not sure when exactly, and my google-fu is
weak tonight.

On the other hand, they introduced ExifInterface(InputStream) in r24.
This can be used even when we do not have permissions / access to the
original file:// URI that the content:// URI resolves to.

So if we are on Android r24+, we use this new API to obtain the EXIF
image orientation and to fix portraits being sideways.