### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,10 @@ def safeExtGet(prop, fallback) {
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', 26)
     buildToolsVersion safeExtGet('buildToolsVersion', "26.0.3")
-
+    
+    lintOptions {
+        disable 'LongLogTag'
+    }
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 16)
         targetSdkVersion safeExtGet('targetSdkVersion', 26)


### PR DESCRIPTION
Long log tag disabled for overcoming an error of long log tag.

issue track: https://github.com/bamlab/react-native-image-resizer/issues/270#issue-788477400