### PR TITLE
fix: don't throw outside promise creation

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,9 +35,9 @@ if (Platform.OS === 'android') {
       keepMeta = false,
       options = {}
     ) => {
-      const validatedOptions = validateOptions(options);
-  
       return new Promise((resolve, reject) => {
+        const validatedOptions = validateOptions(options);
+        
         ImageResizerAndroid.createResizedImage(
           imagePath,
           newWidth,
@@ -67,13 +67,13 @@ if (Platform.OS === 'android') {
       keepMeta = false,
       options = {}
     ) => {
-      if (format !== 'JPEG' && format !== 'PNG') {
-        throw new Error('Only JPEG and PNG format are supported by createResizedImage');
-      }
-  
-      const validatedOptions = validateOptions(options);
-  
       return new Promise((resolve, reject) => {
+        if (format !== 'JPEG' && format !== 'PNG') {
+          throw new Error('Only JPEG and PNG format are supported by createResizedImage');
+        }
+  
+        const validatedOptions = validateOptions(options);
+  
         NativeModules.ImageResizer.createResizedImage(
           path,
           width,


### PR DESCRIPTION
When a function returns a promise all its error handling should result in promise rejections.

For instance this could would have an exception thrown when not using `await` and proper `try...catch` blocks:

```
// on iOS
createResizedImage(..., "webp").catch(console.error.bind(console))
```

This would not print the error but instead throw an exception up the chain.

With the changes in this commit proper exception handling is taken care of.

Both of this works now:

```
// on iOS
createResizedImage(..., "webp").catch(console.error.bind(console))
// or
try {
  await createResizedImage(..., "webp")
} catch(error) {
  console.error(error)  
}
```