### PR TITLE
Fix: [iOS] React requires that all NSNumber arguments are explicitly marked…

### DIFF
--- a/ios/ImageResizer.mm
+++ b/ios/ImageResizer.mm
@@ -16,12 +16,12 @@ NSString *moduleName = @"ImageResizer";
 @implementation ImageResizer
 RCT_EXPORT_MODULE()
 
-RCT_REMAP_METHOD(createdResizedImage, uri:(NSString *)uri width:(double)width height:(double)height format:(NSString *)format quality:(double)quality rotation:(NSNumber *)rotation outputPath:(NSString *)outputPath keepMeta:(NSNumber *)keepMeta mode:(NSString *)mode onlyScaleDown:(NSNumber *)onlyScaleDown resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_REMAP_METHOD(createdResizedImage, uri:(NSString *)uri width:(double)width height:(double)height format:(NSString *)format quality:(double)quality rotation:(nonnull NSNumber *)rotation outputPath:(NSString *)outputPath keepMeta:(nonnull NSNumber *)keepMeta mode:(NSString *)mode onlyScaleDown:(nonnull NSNumber *)onlyScaleDown resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 {
     [self createdResizedImage:uri width:width height:height format:format quality:quality rotation:rotation outputPath:outputPath keepMeta:keepMeta mode:mode onlyScaleDown:onlyScaleDown resolve:resolve reject:reject];
 }
 
-- (void)createdResizedImage:(NSString *)uri width:(double)width height:(double)height format:(NSString *)format quality:(double)quality rotation:(NSNumber *)rotation outputPath:(NSString *)outputPath keepMeta:(NSNumber *)keepMeta mode:(NSString *)mode onlyScaleDown:(NSNumber *)onlyScaleDown resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
+- (void)createdResizedImage:(NSString *)uri width:(double)width height:(double)height format:(NSString *)format quality:(double)quality rotation:(nonnull NSNumber *)rotation outputPath:(NSString *)outputPath keepMeta:(nonnull NSNumber *)keepMeta mode:(NSString *)mode onlyScaleDown:(nonnull NSNumber *)onlyScaleDown resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         @try {
             CGSize newSize = CGSizeMake(width, height);


### PR DESCRIPTION
Fixed below iOS error while resizing images.

`Fix Argument X (NSNumber) of ImageResizer.createdResizedImage has unspecified nullability but React requires that all NSNumber arguments are explicitly marked as nonnull to ensure compatibility with Android error`

Added `nonnull` for NSNumber to avoid above iOS error message.