### PR TITLE
Export method as default like in previous versions

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -19,7 +19,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import { createResizedImage } from '@bam.tech/react-native-image-resizer';
+import ImageResizer from '@bam.tech/react-native-image-resizer';
 import type {
   ResizeMode,
   Response,
@@ -65,7 +65,7 @@ const App = () => {
     setResizedImage(null);
 
     try {
-      let result = await createResizedImage(
+      let result = await ImageResizer.createResizedImage(
         image.uri,
         sizeTarget,
         sizeTarget,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,7 +9,7 @@ const ImageResizer = isTurboModuleEnabled
   ? require('./NativeImageResizer').default
   : NativeModules.ImageResizer;
 
-export function createResizedImage(
+function createResizedImage(
   uri: string,
   width: number,
   height: number,
@@ -55,3 +55,7 @@ export function createResizedImage(
     onlyScaleDown
   );
 }
+
+export default {
+  createResizedImage,
+};


### PR DESCRIPTION
As mentionned in #329, the function `createResizedImage` is not exported as default anymore.

With this PR, the export is the same as the previous versions.