### PR TITLE
Fix : Make option parameter optional

### DIFF
--- a/android/src/legacy/ImageResizerModule.java
+++ b/android/src/legacy/ImageResizerModule.java
@@ -26,7 +26,7 @@ public class ImageResizerModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void createResizedImage(String uri, double width, double height, String format, double quality, Double rotation, @Nullable String outputPath, Boolean keepMeta, @Nullable String mode, Boolean onlyScaleDown, Promise promise) {
+  public void createResizedImage(String uri, double width, double height, String format, double quality, String mode, boolean onlyScaleDown, Double rotation, @Nullable String outputPath, Boolean keepMeta, Promise promise) {
     ImageResizerModuleImpl.createResizedImage(uri, width, height, format, quality, rotation, outputPath, keepMeta, mode, onlyScaleDown, promise, this.context, getReactApplicationContext());
   }
 }

--- a/android/src/turbo/ImageResizerModule.java
+++ b/android/src/turbo/ImageResizerModule.java
@@ -24,7 +24,7 @@ public class ImageResizerModule extends NativeImageResizerSpec {
   }
 
   @Override
-  public void createResizedImage(String uri, double width, double height, String format, double quality, Double rotation, @Nullable String outputPath, Boolean keepMeta, @Nullable String mode, Boolean onlyScaleDown, Promise promise) {
+  public void createResizedImage(String uri, double width, double height, String format, double quality, String mode, boolean onlyScaleDown, Double rotation, @Nullable String outputPath, Boolean keepMeta, Promise promise) {
     ImageResizerModuleImpl.createResizedImage(uri, width, height, format, quality, rotation, outputPath, keepMeta, mode, onlyScaleDown, promise, this.context, getReactApplicationContext());
   }
 }

--- a/ios/ImageResizer.mm
+++ b/ios/ImageResizer.mm
@@ -16,12 +16,12 @@ NSString *moduleName = @"ImageResizer";
 @implementation ImageResizer
 RCT_EXPORT_MODULE()
 
-RCT_REMAP_METHOD(createResizedImage, uri:(NSString *)uri width:(double)width height:(double)height format:(NSString *)format quality:(double)quality rotation:(nonnull NSNumber *)rotation outputPath:(NSString *)outputPath keepMeta:(nonnull NSNumber *)keepMeta mode:(NSString *)mode onlyScaleDown:(nonnull NSNumber *)onlyScaleDown resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_REMAP_METHOD(createResizedImage, uri:(NSString *)uri width:(double)width height:(double)height format:(NSString *)format quality:(double)quality mode:(NSString *)mode onlyScaleDown:(BOOL)onlyScaleDown rotation:(nonnull NSNumber *)rotation outputPath:(NSString *)outputPath keepMeta:(nonnull NSNumber *)keepMeta resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 {
-    [self createResizedImage:uri width:width height:height format:format quality:quality rotation:rotation outputPath:outputPath keepMeta:keepMeta mode:mode onlyScaleDown:onlyScaleDown resolve:resolve reject:reject];
+    [self createResizedImage:uri width:width height:height format:format quality:quality mode:mode onlyScaleDown:onlyScaleDown rotation:rotation outputPath:outputPath keepMeta:keepMeta resolve:resolve reject:reject];
 }
 
-- (void)createResizedImage:(NSString *)uri width:(double)width height:(double)height format:(NSString *)format quality:(double)quality rotation:(nonnull NSNumber *)rotation outputPath:(NSString *)outputPath keepMeta:(nonnull NSNumber *)keepMeta mode:(NSString *)mode onlyScaleDown:(nonnull NSNumber *)onlyScaleDown resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
+- (void)createResizedImage:(NSString *)uri width:(double)width height:(double)height format:(NSString *)format quality:(double)quality mode:(NSString *)mode onlyScaleDown:(BOOL)onlyScaleDown rotation:(nonnull NSNumber *)rotation outputPath:(NSString *)outputPath keepMeta:(nonnull NSNumber *)keepMeta resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         @try {
             CGSize newSize = CGSizeMake(width, height);
@@ -50,7 +50,7 @@ RCT_REMAP_METHOD(createResizedImage, uri:(NSString *)uri width:(double)width hei
 
             UIImage *image;
             image = [UIImage  imageWithData:imageData];
-            NSDictionary * response =  transformImage(image, uri, [rotation integerValue], newSize, fullPath, format, (int)quality, keepMeta, @{@"mode": mode, @"onlyScaleDown": onlyScaleDown});
+            NSDictionary * response =  transformImage(image, uri, [rotation integerValue], newSize, fullPath, format, (int)quality, keepMeta, @{@"mode": mode, @"onlyScaleDown": [NSNumber numberWithBool:onlyScaleDown]});
             resolve(response);
         } @catch (NSException *exception) {
             RCTLogError([NSString stringWithFormat:@"Code : %@ / Message : %@", exception.name, exception.reason]);

--- a/src/NativeImageResizer.ts
+++ b/src/NativeImageResizer.ts
@@ -8,11 +8,11 @@ export interface Spec extends TurboModule {
     height: number,
     format: string,
     quality: number,
+    mode: string,
+    onlyScaleDown: boolean,
     rotation?: number,
     outputPath?: string,
-    keepMeta?: boolean,
-    mode?: string,
-    onlyScaleDown?: boolean
+    keepMeta?: boolean
   ): Promise<{
     path: string;
     uri: string;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,7 +18,7 @@ export function createResizedImage(
   rotation?: number,
   outputPath?: string,
   keepMeta?: boolean,
-  options?: {
+  options: {
     /**
      * Either `contain` (the default), `cover`, or `stretch`. Similar to
      * [react-native <Image>'s resizeMode](https://reactnative.dev/docs/image#resizemode)
@@ -37,10 +37,13 @@ export function createResizedImage(
      * (Default: false)
      */
     onlyScaleDown?: boolean;
+  } = {
+    mode: 'contain',
+    onlyScaleDown: false,
   }
 ): Promise<Response> {
-  const mode = options?.mode;
-  const onlyScaleDown = options?.onlyScaleDown;
+  const mode = options.mode;
+  const onlyScaleDown = options.onlyScaleDown;
 
   return ImageResizer.createResizedImage(
     uri,
@@ -48,10 +51,10 @@ export function createResizedImage(
     height,
     format,
     quality,
+    mode,
+    onlyScaleDown,
     rotation,
     outputPath,
-    keepMeta,
-    mode,
-    onlyScaleDown
+    keepMeta
   );
 }


### PR DESCRIPTION
As mentioned in #329 if we do not specify the `option` parameter it results in a crash.

This PR makes it optional like it was before.
