### PR TITLE
:bug:  Set rotation & keepMeta default value

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,9 +20,9 @@ function createResizedImage(
   height: number,
   format: ResizeFormat,
   quality: number,
-  rotation?: number,
+  rotation: number = 0,
   outputPath?: string,
-  keepMeta?: boolean,
+  keepMeta = false,
   options: Options = defaultOptions
 ): Promise<Response> {
   const { mode, onlyScaleDown } = { ...defaultOptions, ...options };


### PR DESCRIPTION
In previous version rotation & keepMeta had default value. Not specifying these values result in a crash on native side because they are expected to be defined.

Related issue : #341

Code from 1.4.5
https://github.com/bamlab/react-native-image-resizer/blob/v1.4.5/index.js