### PR TITLE
Issue 328 ios fix image loading using uri or path

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,12 @@ A basic, sample app is available in [the `example` folder](https://github.com/ba
 
 ```javascript
 createResizedImage(
-  path,
+  /**
+   * uri parameter accepts`path` or `uri`.
+   * This property has been tested with the output of @bam.tech/react-native-image-picker,
+   * react-native-vision-camera, @react-native-camera-roll/camera-roll and http link
+   **/
+  uri,
   maxWidth,
   maxHeight,
   compressFormat,
@@ -90,6 +95,10 @@ The promise resolves with an object containing: `path`, `uri`, `name`, `size` (b
 | keepMeta              | If `true`, will attempt to preserve all file metadata/exif info, except the orientation value since the resizing also does rotation correction to the original image. Defaults to `false`, which means all metadata is lost. Note: This can only be `true` for `JPEG` images which are loaded from the file system (not Web).                                                                                |
 | options.mode          | Similar to [react-native Image's resizeMode](https://reactnative.dev/docs/image#resizemode): either `contain` (the default), `cover`, or `stretch`. `contain` will fit the image within `width` and `height`, preserving its ratio. `cover` preserves the aspect ratio, and makes sure the image is at least `width` wide or `height` tall. `stretch` will resize the image to exactly `width` and `height`. |
 | options.onlyScaleDown | If `true`, will never enlarge the image, and will only make it smaller.                                                                                                                                                                                                                                                                                                                                      |
+
+# Limitations
+
+- If you are using `@react-native-camera-roll/camera-roll` **with new architecture enabled this library is not going to work**. If you try to display an image with the `uri` of the library using `<Image />` you are going to have the following error: `No suitable image URL loader found for ph://...`. This error come from the ReactNative `ImageLoader`, which is the one we are currently using. Help/PR for solving this are welcome. Until then, we recommend using `react-native-image-picker`.
 
 ## 👉 About Bam
 

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.CAMERA" />
 
     <application
       android:name=".MainApplication"

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,11 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application
       android:name=".MainApplication"

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -6,6 +6,7 @@ buildscript {
         minSdkVersion = 21
         compileSdkVersion = 33
         targetSdkVersion = 33
+        kotlinVersion = "1.6.20"
 
         // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.
         ndkVersion = "23.1.7779620"

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -418,6 +418,10 @@ PODS:
     - React-logger (= 0.71.8)
     - React-perflogger (= 0.71.8)
   - SocketRocket (0.6.0)
+  - VisionCamera (2.15.6):
+    - React
+    - React-callinvoker
+    - React-Core
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -483,6 +487,7 @@ DEPENDENCIES:
   - React-RCTVibration (from `../node_modules/react-native/Libraries/Vibration`)
   - React-runtimeexecutor (from `../node_modules/react-native/ReactCommon/runtimeexecutor`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
+  - VisionCamera (from `../node_modules/react-native-vision-camera`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -574,13 +579,15 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/runtimeexecutor"
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
+  VisionCamera:
+    :path: "../node_modules/react-native-vision-camera"
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: 57d2868c099736d80fcd648bf211b4431e51a558
+  boost: a7c83b31436843459a1961bfd74b96033dc77234
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
+  DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
   FBLazyVector: f637f31eacba90d4fdeff3fa41608b8f361c173b
   FBReactNativeSpec: 0d9a4f4de7ab614c49e98c00aedfd3bfbda33d59
   Flipper: 26fc4b7382499f1281eb8cb921e5c3ad6de91fe0
@@ -593,7 +600,7 @@ SPEC CHECKSUMS:
   Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
   FlipperKit: cbdee19bdd4e7f05472a66ce290f1b729ba3cb86
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
+  glog: 476ee3e89abb49e07f822b48323c51c57124b572
   hermes-engine: 47986d26692ae75ee7a17ab049caee8864f855de
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
@@ -627,9 +634,10 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: 7c51ae9d4b3e9608a2366e39ccaa606aa551b9ed
   ReactCommon: 85c98ab0a509e70bf5ee5d9715cf68dbf495b84c
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
+  VisionCamera: 523b49054bee9dace64189ab6631cb41e8b83fe0
   Yoga: 065f0b74dba4832d6e328238de46eb72c5de9556
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: d12e6625eb5869c057639e02d65105cb9b470445
 
-COCOAPODS: 1.12.0
+COCOAPODS: 1.12.1

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -329,6 +329,8 @@ PODS:
   - React-jsinspector (0.71.8)
   - React-logger (0.71.8):
     - glog
+  - react-native-cameraroll (5.7.2):
+    - React-Core
   - react-native-image-picker (4.10.3):
     - React-Core
   - react-native-image-resizer (3.0.5):
@@ -472,6 +474,7 @@ DEPENDENCIES:
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
+  - "react-native-cameraroll (from `../node_modules/@react-native-camera-roll/camera-roll`)"
   - react-native-image-picker (from `../node_modules/react-native-image-picker`)
   - react-native-image-resizer (from `../..`)
   - React-perflogger (from `../node_modules/react-native/ReactCommon/reactperflogger`)
@@ -549,6 +552,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
   React-logger:
     :path: "../node_modules/react-native/ReactCommon/logger"
+  react-native-cameraroll:
+    :path: "../node_modules/@react-native-camera-roll/camera-roll"
   react-native-image-picker:
     :path: "../node_modules/react-native-image-picker"
   react-native-image-resizer:
@@ -618,6 +623,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 747911ab5921641b4ed7e4900065896597142125
   React-jsinspector: c712f9e3bb9ba4122d6b82b4f906448b8a281580
   React-logger: 342f358b8decfbf8f272367f4eacf4b6154061be
+  react-native-cameraroll: 134805127580aed23403b8c2cb1548920dd77b3a
   react-native-image-picker: 60f4246eb5bb7187fc15638a8c1f13abd3820695
   react-native-image-resizer: 00ceb0e05586c7aadf061eea676957a6c2ec60fa
   React-perflogger: d21f182895de9d1b077f8a3cd00011095c8c9100

--- a/example/ios/ReactNativeImageResizerExample/Info.plist
+++ b/example/ios/ReactNativeImageResizerExample/Info.plist
@@ -51,5 +51,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>NSCameraUsageDescription</key>
+	<string>$(PRODUCT_NAME) needs access to your Camera.</string>
 </dict>
 </plist>

--- a/example/ios/ReactNativeImageResizerExample/Info.plist
+++ b/example/ios/ReactNativeImageResizerExample/Info.plist
@@ -53,5 +53,9 @@
 	<false/>
 	<key>NSCameraUsageDescription</key>
 	<string>$(PRODUCT_NAME) needs access to your Camera.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>$(PRODUCT_NAME) needs access your photo library.</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>$(PRODUCT_NAME) needs access your photo library.</string>
 </dict>
 </plist>

--- a/example/package.json
+++ b/example/package.json
@@ -11,13 +11,14 @@
   "dependencies": {
     "react": "18.2.0",
     "react-native": "0.71.8",
-    "react-native-image-picker": "^4.8.4"
+    "react-native-image-picker": "^4.8.4",
+    "react-native-vision-camera": "^2.15.6"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
     "@babel/preset-env": "^7.20.0",
     "@babel/runtime": "^7.20.0",
-    "metro-react-native-babel-preset": "0.73.9",
-    "babel-plugin-module-resolver": "^4.1.0"
+    "babel-plugin-module-resolver": "^4.1.0",
+    "metro-react-native-babel-preset": "0.73.9"
   }
 }

--- a/example/package.json
+++ b/example/package.json
@@ -9,6 +9,7 @@
     "pods": "pod-install --quiet"
   },
   "dependencies": {
+    "@react-native-camera-roll/camera-roll": "^5.7.2",
     "react": "18.2.0",
     "react-native": "0.71.8",
     "react-native-image-picker": "^4.8.4",

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -17,6 +17,7 @@ import {
   StyleSheet,
   Text,
   TextInput,
+  TextInputComponent,
   TouchableOpacity,
   View,
 } from 'react-native';
@@ -61,6 +62,7 @@ const App = () => {
   const [sizeTarget, setSizeTarget] = useState(80);
   const [resizedImage, setResizedImage] = useState<null | Response>();
   const [isCameraActive, setIsCameraActive] = useState(false);
+  const [inputImageUrl, setInputImageUrl] = useState('');
   const devices = useCameraDevices();
   const device = devices.back;
   const camera = useRef<Camera>(null);
@@ -133,6 +135,8 @@ const App = () => {
     closeCamera();
   };
 
+  const loadImageFromUrl = () => setImageUri(inputImageUrl);
+
   const closeCamera = () => setIsCameraActive(false);
 
   if (isCameraActive && device !== undefined) {
@@ -174,6 +178,15 @@ const App = () => {
       <View style={styles.imageSourceButtonContainer}>
         <TouchableOpacity style={styles.button} onPress={openCamera}>
           <Text>Take a photo</Text>
+        </TouchableOpacity>
+      </View>
+      <TextInput
+        style={styles.urlInput}
+        onChangeText={(text) => setInputImageUrl(text)}
+      />
+      <View style={styles.imageSourceButtonContainer}>
+        <TouchableOpacity style={styles.button} onPress={loadImageFromUrl}>
+          <Text>Load image from url</Text>
         </TouchableOpacity>
       </View>
       <Text style={styles.instructions}>This is the original image:</Text>
@@ -301,6 +314,15 @@ const styles = StyleSheet.create({
     paddingHorizontal: 10,
     paddingVertical: 10,
     borderRadius: 10,
+  },
+  urlInput: {
+    height: 40,
+    borderColor: 'black',
+    borderWidth: 2,
+    margin: 10,
+    alignSelf: 'stretch',
+    textAlign: 'center',
+    overflow: 'hidden',
   },
 });
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -333,7 +333,7 @@ const styles = StyleSheet.create({
   },
   container: {
     paddingVertical: 100,
-    alignItems: 'center',
+    paddingHorizontal: 10,
   },
   cameraContainer: {
     flex: 1,
@@ -353,9 +353,6 @@ const styles = StyleSheet.create({
   },
   image: {
     height: 250,
-    borderWidth: 1,
-    borderColor: 'black',
-    alignSelf: 'stretch',
     marginBottom: 10,
   },
   resizeButton: {

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1267,6 +1267,11 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
+"@react-native-camera-roll/camera-roll@^5.7.2":
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/@react-native-camera-roll/camera-roll/-/camera-roll-5.7.2.tgz#db11525ae26c8a61630c424aebd323a7c784a921"
+  integrity sha512-s8VAUG1Kvi+tEJkLHObmOJdXAL/uclnXJ/IdnJtx2fCKiWA3Ho0ln9gDQqCYHHHHu+sXk7wovsH/I2/AYy0brg==
+
 "@react-native-community/cli-clean@^10.1.1":
   version "10.1.1"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-10.1.1.tgz#4c73ce93a63a24d70c0089d4025daac8184ff504"

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -3927,6 +3927,11 @@ react-native-image-picker@^4.8.4:
   resolved "https://registry.yarnpkg.com/react-native-image-picker/-/react-native-image-picker-4.10.3.tgz#cdc11d9836b4cfa57e658c0700201babf8fdca10"
   integrity sha512-gLX8J6jCBkUt6jogpSdA7YyaGVLGYywRzMEwBciXshihpFZjc/cRlKymAVlu6Q7HMw0j3vrho6pI8ZGC5O/FGg==
 
+react-native-vision-camera@^2.15.6:
+  version "2.15.6"
+  resolved "https://registry.yarnpkg.com/react-native-vision-camera/-/react-native-vision-camera-2.15.6.tgz#50fe9b47117a257f2c8bf7c33994fdadb897d091"
+  integrity sha512-TEdriQ2SQAhF7byw7iDaOh8cJm/IECOUofBhcdswtAK9LSqCkVEIhX3pna2L3Obt6evc8zaFnYCVqhvC3UtKRg==
+
 react-native@0.71.8:
   version "0.71.8"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.71.8.tgz#4314145341c49448cf7465b93ced52a433a5e191"

--- a/ios/ImageResizer.mm
+++ b/ios/ImageResizer.mm
@@ -14,6 +14,9 @@
 NSString *moduleName = @"ImageResizer";
 
 @implementation ImageResizer
+
+@synthesize bridge = _bridge;
+
 RCT_EXPORT_MODULE()
 
 RCT_REMAP_METHOD(createResizedImage, uri:(NSString *)uri width:(double)width height:(double)height format:(NSString *)format quality:(double)quality mode:(NSString *)mode onlyScaleDown:(BOOL)onlyScaleDown rotation:(nonnull NSNumber *)rotation outputPath:(NSString *)outputPath keepMeta:(nonnull NSNumber *)keepMeta resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
@@ -25,35 +28,40 @@ RCT_REMAP_METHOD(createResizedImage, uri:(NSString *)uri width:(double)width hei
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         @try {
             CGSize newSize = CGSizeMake(width, height);
-
+            
             //Set image extension
             NSString *extension = @"jpg";
             if ([format isEqualToString:@"PNG"]) {
                 extension = @"png";
             }
-
+            
             NSString* fullPath;
             @try {
                 fullPath = generateFilePath(extension, outputPath);
             } @catch (NSException *exception) {
                 [NSException raise:moduleName format:@"Invalid output path."];
             }
-
-            NSURL * fileURL = [[NSURL alloc] initWithString:uri];
-
-            NSError *err;
-            if ([fileURL checkResourceIsReachableAndReturnError:&err] == NO){
-                [NSException raise:moduleName format:@"Image uri invalid."];
-            }
-
-            NSData * imageData = [NSData dataWithContentsOfURL:fileURL];
-
-            UIImage *image;
-            image = [UIImage  imageWithData:imageData];
-            NSDictionary * response =  transformImage(image, uri, [rotation integerValue], newSize, fullPath, format, (int)quality, [keepMeta boolValue], @{@"mode": mode, @"onlyScaleDown": [NSNumber numberWithBool:onlyScaleDown]});
-            resolve(response);
+            
+            RCTImageLoader *loader = [self.bridge moduleForName:@"ImageLoader" lazilyLoadIfNecessary:YES];
+            NSURLRequest *request = [RCTConvert NSURLRequest:uri];
+            [loader loadImageWithURLRequest:request
+                                       size:newSize
+                                      scale:1
+                                    clipped:NO
+                                 resizeMode:RCTResizeModeContain
+                              progressBlock:nil
+                           partialLoadBlock:nil
+                            completionBlock:^(NSError *error, UIImage *image) {
+                if (error) {
+                    RCTLogError(@"%@", [NSString stringWithFormat:@"Code : %@ / Message : %@", [NSString stringWithFormat: @"%ld", (long)error.code], error.description]);
+                    reject([NSString stringWithFormat: @"%ld", (long)error.code], error.description, nil);
+                    return;
+                }
+                NSDictionary * response =  transformImage(image, uri, [rotation integerValue], newSize, fullPath, format, (int)quality, [keepMeta boolValue], @{@"mode": mode, @"onlyScaleDown": [NSNumber numberWithBool:onlyScaleDown]});
+                resolve(response);
+            }];
         } @catch (NSException *exception) {
-            RCTLogError([NSString stringWithFormat:@"Code : %@ / Message : %@", exception.name, exception.reason]);
+            RCTLogError(@"%@", [NSString stringWithFormat:@"Code : %@ / Message : %@", exception.name, exception.reason]);
             reject(exception.name, exception.reason, nil);
         }
     });
@@ -70,20 +78,20 @@ bool saveImage(NSString * fullPath, UIImage * image, NSString * format, float qu
         } else if ([format isEqualToString:@"PNG"]) {
             data = UIImagePNGRepresentation(image);
         }
-
+        
         if (data == nil) {
             return NO;
         }
-
+        
         NSFileManager* fileManager = [NSFileManager defaultManager];
         return [fileManager createFileAtPath:fullPath contents:data attributes:nil];
     }
-
+    
     // process / write metadata together with image data
     else{
-
+        
         CFStringRef imgType = kUTTypeJPEG;
-
+        
         if ([format isEqualToString:@"JPEG"]) {
             [metadata setObject:@(quality / 100.0) forKey:(__bridge NSString *)kCGImageDestinationLossyCompressionQuality];
         }
@@ -93,17 +101,17 @@ bool saveImage(NSString * fullPath, UIImage * image, NSString * format, float qu
         else{
             return NO;
         }
-
+        
         NSMutableData * destData = [NSMutableData data];
-
+        
         CGImageDestinationRef destination = CGImageDestinationCreateWithData((__bridge CFMutableDataRef)destData, imgType, 1, NULL);
-
+        
         @try{
             CGImageDestinationAddImage(destination, image.CGImage, (__bridge CFDictionaryRef) metadata);
-
+            
             // write final image data with metadata to our destination
             if (CGImageDestinationFinalize(destination)){
-
+                
                 NSFileManager* fileManager = [NSFileManager defaultManager];
                 return [fileManager createFileAtPath:fullPath contents:destData attributes:nil];
             }
@@ -125,7 +133,7 @@ bool saveImage(NSString * fullPath, UIImage * image, NSString * format, float qu
 NSString * generateFilePath(NSString * ext, NSString * outputPath)
 {
     NSString* directory;
-
+    
     if ([outputPath length] == 0) {
         NSArray* paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
         directory = [paths firstObject];
@@ -137,7 +145,7 @@ NSString * generateFilePath(NSString * ext, NSString * outputPath)
         } else {
             directory = [documentsDirectory stringByAppendingPathComponent:outputPath];
         }
-
+        
         NSError *error;
         [[NSFileManager defaultManager] createDirectoryAtPath:directory withIntermediateDirectories:YES attributes:nil error:&error];
         if (error) {
@@ -145,29 +153,29 @@ NSString * generateFilePath(NSString * ext, NSString * outputPath)
             @throw [NSException exceptionWithName:@"InvalidPathException" reason:[NSString stringWithFormat:@"Error creating documents subdirectory: %@", error] userInfo:nil];
         }
     }
-
+    
     NSString* name = [[NSUUID UUID] UUIDString];
     NSString* fullName = [NSString stringWithFormat:@"%@.%@", name, ext];
     NSString* fullPath = [directory stringByAppendingPathComponent:fullName];
-
+    
     return fullPath;
 }
 
 UIImage * rotateImage(UIImage *inputImage, float rotationDegrees)
 {
-
+    
     // We want only fixed 0, 90, 180, 270 degree rotations.
     const int rotDiv90 = (int)round(rotationDegrees / 90);
     const int rotQuadrant = rotDiv90 % 4;
     const int rotQuadrantAbs = (rotQuadrant < 0) ? rotQuadrant + 4 : rotQuadrant;
-
+    
     // Return the input image if no rotation specified.
     if (0 == rotQuadrantAbs) {
         return inputImage;
     } else {
         // Rotate the image by 80, 180, 270.
         UIImageOrientation orientation = UIImageOrientationUp;
-
+        
         switch(rotQuadrantAbs) {
             case 1:
                 orientation = UIImageOrientationRight; // 90 deg CW
@@ -179,10 +187,10 @@ UIImage * rotateImage(UIImage *inputImage, float rotationDegrees)
                 orientation = UIImageOrientationLeft; // 90 deg CCW
                 break;
         }
-
+        
         return [[UIImage alloc] initWithCGImage: inputImage.CGImage
-                                                  scale: 1.0
-                                                  orientation: orientation];
+                                          scale: 1.0
+                                    orientation: orientation];
     }
 }
 
@@ -193,19 +201,19 @@ float getScaleForProportionalResize(CGSize theSize, CGSize intoSize, bool onlySc
     float    dx = intoSize.width;
     float    dy = intoSize.height;
     float    scale    = 1;
-
+    
     if( sx != 0 && sy != 0 )
     {
         dx    = dx / sx;
         dy    = dy / sy;
-
+        
         // if maximize is true, take LARGER of the scales, else smaller
         if (maximize) {
             scale = MAX(dx, dy);
         } else {
             scale = MIN(dx, dy);
         }
-
+        
         if (onlyScaleDown) {
             scale = MIN(scale, 1);
         }
@@ -224,27 +232,27 @@ float getScaleForProportionalResize(CGSize theSize, CGSize intoSize, bool onlySc
 // so no additional scaling math needs to be done to get its pixel dimensions
 UIImage* scaleImage (UIImage* image, CGSize toSize, NSString* mode, bool onlyScaleDown)
 {
-
+    
     // Need to do scaling corrections
     // based on scale, since UIImage width/height gives us
     // a possibly scaled image (dimensions in points)
     // Idea taken from RNCamera resize code
     CGSize imageSize = CGSizeMake(image.size.width * image.scale, image.size.height * image.scale);
-
+    
     // using this instead of ImageHelpers allows us to consider
     // rotation variations
     CGSize newSize;
-
+    
     if ([mode isEqualToString:@"stretch"]) {
         // Distort aspect ratio
         int width = toSize.width;
         int height = toSize.height;
-
+        
         if (onlyScaleDown) {
             width = MIN(width, imageSize.width);
             height = MIN(height, imageSize.height);
         }
-
+        
         newSize = CGSizeMake(width, height);
     } else {
         // Either "contain" (default) or "cover": preserve aspect ratio
@@ -252,7 +260,7 @@ UIImage* scaleImage (UIImage* image, CGSize toSize, NSString* mode, bool onlySca
         float scale = getScaleForProportionalResize(imageSize, toSize, onlyScaleDown, maximize);
         newSize = CGSizeMake(roundf(imageSize.width * scale), roundf(imageSize.height * scale));
     }
-
+    
     UIGraphicsBeginImageContextWithOptions(newSize, NO, 1.0);
     [image drawInRect:CGRectMake(0, 0, newSize.width, newSize.height)];
     UIImage *newImage = UIGraphicsGetImageFromCurrentImageContext();
@@ -264,83 +272,83 @@ UIImage* scaleImage (UIImage* image, CGSize toSize, NSString* mode, bool onlySca
 NSMutableDictionary * getImageMeta(NSString * path)
 {
     if([path hasPrefix:@"assets-library"]) {
-
+        
         __block NSMutableDictionary* res = nil;
-
+        
         ALAssetsLibraryAssetForURLResultBlock resultblock = ^(ALAsset *myasset)
         {
-
+            
             NSDictionary *exif = [[myasset defaultRepresentation] metadata];
             res = [exif mutableCopy];
-
+            
         };
-
+        
         ALAssetsLibrary* assetslibrary = [[ALAssetsLibrary alloc] init];
         NSURL *url = [NSURL URLWithString:[path stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
-
+        
         [assetslibrary assetForURL:url resultBlock:resultblock failureBlock:^(NSError *error) { NSLog(@"error couldn't image from assets library"); }];
-
+        
         return res;
-
+        
     } else {
-
+        
         NSData* imageData = nil;
-
+        
         if ([path hasPrefix:@"data:"] || [path hasPrefix:@"file:"]) {
             NSURL *imageUrl = [[NSURL alloc] initWithString:path];
             imageData = [NSData dataWithContentsOfURL:imageUrl];
-
+            
         } else {
             imageData = [NSData dataWithContentsOfFile:path];
         }
-
+        
         if(imageData == nil){
             NSLog(@"Could not get image file data to extract metadata.");
             return nil;
         }
-
+        
         CGImageSourceRef source = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
-
-
+        
+        
         if(source != nil){
-
+            
             CFDictionaryRef metaRef = CGImageSourceCopyPropertiesAtIndex(source, 0, NULL);
-
+            
             // release CF image
             CFRelease(source);
-
+            
             CFMutableDictionaryRef metaRefMutable = CFDictionaryCreateMutableCopy(NULL, 0, metaRef);
-
+            
             // release the source meta ref now that we've copie it
             CFRelease(metaRef);
-
+            
             // bridge CF object so it auto releases
             NSMutableDictionary* res = (NSMutableDictionary *)CFBridgingRelease(metaRefMutable);
-
+            
             return res;
-
+            
         }
         else{
             return nil;
         }
-
+        
     }
 }
 
 NSDictionary * transformImage(UIImage *image,
-                    NSString * originalPath,
-                    int rotation,
-                    CGSize newSize,
-                    NSString* fullPath,
-                    NSString* format,
-                    int quality,
-                    BOOL keepMeta,
-                    NSDictionary* options)
+                              NSString * originalPath,
+                              int rotation,
+                              CGSize newSize,
+                              NSString* fullPath,
+                              NSString* format,
+                              int quality,
+                              BOOL keepMeta,
+                              NSDictionary* options)
 {
     if (image == nil) {
         [NSException raise:moduleName format:@"Can't retrieve the file from the path."];
     }
-
+    
     // Rotate image if rotation is specified.
     if (0 != (int)rotation) {
         image = rotateImage(image, rotation);
@@ -348,40 +356,40 @@ NSDictionary * transformImage(UIImage *image,
             [NSException raise:moduleName format:@"Can't rotate the image."];
         }
     }
-
+    
     // Do the resizing
     UIImage * scaledImage = scaleImage(
-        image,
-        newSize,
-        options[@"mode"],
-        [[options objectForKey:@"onlyScaleDown"] boolValue]
-    );
-
+                                       image,
+                                       newSize,
+                                       options[@"mode"],
+                                       [[options objectForKey:@"onlyScaleDown"] boolValue]
+                                       );
+    
     if (scaledImage == nil) {
         [NSException raise:moduleName format:@"Can't resize the image."];
     }
-
-
+    
+    
     NSMutableDictionary *metadata = nil;
-
+    
     // to be consistent with Android, we will only allow JPEG
     // to do this.
     if(keepMeta && [format isEqualToString:@"JPEG"]){
-
+        
         metadata = getImageMeta(originalPath);
-
+        
         // remove orientation (since we fix it)
         // width/height meta is adjusted automatically
         // NOTE: This might still leave some stale values due to resize
         metadata[(NSString*)kCGImagePropertyOrientation] = @(1);
-
+        
     }
-
+    
     // Compress and save the image
     if (!saveImage(fullPath, scaledImage, format, quality, metadata)) {
         [NSException raise:moduleName format:@"Can't save the image. Check your compression format and your output path"];
     }
-
+    
     NSURL *fileUrl = [[NSURL alloc] initFileURLWithPath:fullPath];
     NSString *fileName = fileUrl.lastPathComponent;
     NSError *attributesError = nil;
@@ -393,15 +401,15 @@ NSDictionary * transformImage(UIImage *image,
                                @"size": fileSize == nil ? @(0) : fileSize,
                                @"width": @(scaledImage.size.width),
                                @"height": @(scaledImage.size.height),
-                               };
-
+    };
+    
     return response;
 }
 
 // Don't compile this code when we build for the old architecture.
 #ifdef RCT_NEW_ARCH_ENABLED
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
-    (const facebook::react::ObjCTurboModule::InitParams &)params
+(const facebook::react::ObjCTurboModule::InitParams &)params
 {
     return std::make_shared<facebook::react::NativeImageResizerSpecJSI>(params);
 }


### PR DESCRIPTION
# Problem
This fix the issue #328.
iOS was only accepted `uri`using scheme `file://`. This is a regression from version < `3.x.x`.

# Solution
The solution was to use the React-Native url converter & image loader in order to handle both `path` & `uri` (with several protocol/scheme).

# Test

This PR also add several image sources in the example application using:
- `react-native-image-picker`;
- `react-native-vision-camera`;
- `@react-native-camera-roll/camera-roll`;
- simple url (i.e. `http://.....`);

||ios|android|
|:-:|:-:|:-:|
|New arch **OFF**|https://github.com/bamlab/react-native-image-resizer/assets/9041221/2813ed1c-7929-45f1-9464-336a24f989c0|https://github.com/bamlab/react-native-image-resizer/assets/9041221/c519f3b9-e297-45e0-bd8b-1e6bbfe13c39|
|New arch **ON**|https://github.com/bamlab/react-native-image-resizer/assets/9041221/cdd72618-9cca-44ac-a9b0-8cd2a92fd768|https://github.com/bamlab/react-native-image-resizer/assets/9041221/4b2c5f8a-3edd-4ad0-81f9-6c4daa9d4d5f|












