### PR TITLE
Delete useless folly version in podspec

### DIFF
--- a/react-native-image-resizer.podspec
+++ b/react-native-image-resizer.podspec
@@ -1,7 +1,6 @@
 require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
-folly_version = '2021.06.28.00-v2'
 folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 
 Pod::Spec.new do |s|


### PR DESCRIPTION
# Problem

The initial problem was reported in #375.
We were specifying the folly version instead of using the one specified by the react native version on the host app.

# Solution

This has been fixed during the upgrade of the example app in this PR: #370.
This PR is just here the variable `folly_version` that is not needed anymore.