### PR TITLE
Fix: rotation on some android devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ The promise resolves with an object containing: `path`, `uri`, `name`, `size` (b
 # Limitations
 
 - If you are using `@react-native-camera-roll/camera-roll` **with new architecture enabled this library is not going to work**. If you try to display an image with the `uri` of the library using `<Image />` you are going to have the following error: `No suitable image URL loader found for ph://...`. This error come from the ReactNative `ImageLoader`, which is the one we are currently using. Help/PR for solving this are welcome. Until then, we recommend using `react-native-image-picker`.
+- Image EXIF orientation are correctly handled on Android only, But not yet on IOS [#402](https://github.com/bamlab/react-native-image-resizer/issues/402).
 
 ## 👉 About Bam
 

--- a/android/src/main/java/com/reactnativeimageresizer/ImageResizer.java
+++ b/android/src/main/java/com/reactnativeimageresizer/ImageResizer.java
@@ -338,7 +338,7 @@ public class ImageResizer {
    * Convert metadata to degrees
    */
   public static int getOrientation(ExifInterface exif) {
-    int orientation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL);
+    int orientation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_UNDEFINED);
     switch (orientation) {
       case ExifInterface.ORIENTATION_TRANSPOSE:
       case ExifInterface.ORIENTATION_ROTATE_90:
@@ -553,7 +553,6 @@ public class ImageResizer {
     // NOTE: This will "fix" the image using it's exif info if it is rotated as well.
     Bitmap rotatedImage = sourceImage;
     int orientation = getOrientation(context, imageUri);
-
     rotation = orientation + rotation;
     rotatedImage = ImageResizer.rotateImage(sourceImage, rotation);
 

--- a/android/src/main/java/com/reactnativeimageresizer/ImageResizer.java
+++ b/android/src/main/java/com/reactnativeimageresizer/ImageResizer.java
@@ -340,10 +340,13 @@ public class ImageResizer {
   public static int getOrientation(ExifInterface exif) {
     int orientation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL);
     switch (orientation) {
+      case ExifInterface.ORIENTATION_TRANSPOSE:
       case ExifInterface.ORIENTATION_ROTATE_90:
         return 90;
+      case ExifInterface.ORIENTATION_FLIP_VERTICAL:
       case ExifInterface.ORIENTATION_ROTATE_180:
         return 180;
+      case ExifInterface.ORIENTATION_TRANSVERSE:
       case ExifInterface.ORIENTATION_ROTATE_270:
         return 270;
       default:
@@ -550,6 +553,7 @@ public class ImageResizer {
     // NOTE: This will "fix" the image using it's exif info if it is rotated as well.
     Bitmap rotatedImage = sourceImage;
     int orientation = getOrientation(context, imageUri);
+
     rotation = orientation + rotation;
     rotatedImage = ImageResizer.rotateImage(sourceImage, rotation);
 
@@ -557,7 +561,7 @@ public class ImageResizer {
       throw new IOException("Unable to rotate image. Most likely due to not enough memory.");
     }
 
-    if (rotatedImage != rotatedImage) {
+    if (rotatedImage != sourceImage) {
       sourceImage.recycle();
     }
 


### PR DESCRIPTION
## Error
On some android devices the photo is rotated

## Solution
This caused by lack of some exif rotation is not read on creating the new bitmap for rotation.

