### PR TITLE
fix: add missing package name

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.reactnativeimageresizer">
 
 </manifest>


### PR DESCRIPTION
The `package` attribute was missing from the `<manifest>` tag in `AndroidManifest.xml`.

This was causing an error when running the project on android.