### PR TITLE
fix(android): handle namespace properly starting AGP 8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,7 +33,17 @@ def getExtOrIntegerDefault(name) {
 
 android {
   compileSdkVersion getExtOrIntegerDefault("compileSdkVersion")
-  namespace "com.reactnativeimageresizer"
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+  def agpMajorVersion = agpVersion.tokenize('.')[0].toInteger()
+  def agpMinorVersion = agpVersion.tokenize('.')[1].toInteger()
+  /**
+  * Namespace should be declared here starting from AGP 8.x, Starting AGP 7.3 it is also supported.
+  * For AGP < 7.3, namespace should be declared in AndroidManifest.
+  * See: https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes#namespace-dsl
+  */
+  if (agpMajorVersion >= 7 && agpMinorVersion >= 3) {
+      namespace "com.reactnativeimageresizer"
+  }
 
   defaultConfig {
     minSdkVersion getExtOrIntegerDefault("minSdkVersion")

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.reactnativeimageresizer">
 
 </manifest>


### PR DESCRIPTION
Namespace should be declared in `build.gradle` starting from AGP 8.x, Starting AGP 7.3 it is also supported.
For AGP < 7.3, namespace should be declared in AndroidManifest.
See: https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes#namespace-dsl

See also this discussion: https://github.com/react-native-community/discussions-and-proposals/issues/671

Has been tested on RN `0.70`, `0.71` & `0.74`