### PR TITLE
Apply namespace when agp version is between 8.0 and 8.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,7 +41,7 @@ android {
   * For AGP < 7.3, namespace should be declared in AndroidManifest.
   * See: https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes#namespace-dsl
   */
-  if (agpMajorVersion >= 7 && agpMinorVersion >= 3) {
+  if (agpMajorVersion >= 8 || (agpMajorVersion == 7 && agpMinorVersion >= 3)) {
       namespace "com.reactnativeimageresizer"
   }
 


### PR DESCRIPTION
Follow-up to https://github.com/bamlab/react-native-image-resizer/pull/401. 

Updates the namespace logic so that it the minor version only has to be `>= 3` if the major version is `== 7`. This allows the namespace to be applied for versions like `8.0`, `8.1`, and `8.2`.