### PR TITLE
Fix AGP Version Check for Namespace Setting

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,7 +41,7 @@ android {
   * For AGP < 7.3, namespace should be declared in AndroidManifest.
   * See: https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes#namespace-dsl
   */
-  if (agpMajorVersion >= 7 && agpMinorVersion >= 3) {
+  if ((agpMajorVersion == 7 && agpMinorVersion >= 3) || agpMajorVersion > 7) {
       namespace "com.reactnativeimageresizer"
   }
 


### PR DESCRIPTION
I had an issue with the namespace setting for AGP version 8.1. Due to a separate minor version check, versions like 8.1 or 8.2 did not have the correct namespace set. This PR fixes the issue by applying the minor version check only for 7.x versions.