### PR TITLE
fix: update codegen config

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,12 +169,8 @@
     ]
   },
   "codegenConfig": {
-    "libraries": [
-      {
-        "name": "RNImageResizerSpec",
-        "type": "modules",
-        "jsSrcsDir": "src"
-      }
-    ]
+    "name": "RNImageResizerSpec",
+    "type": "modules",
+    "jsSrcsDir": "src"
   }
 }

--- a/react-native-image-resizer.podspec
+++ b/react-native-image-resizer.podspec
@@ -16,7 +16,6 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm}"
 
-  s.dependency "React-Core"
   s.ios.framework = 'AssetsLibrary', 'MobileCoreServices'
 
   # Don't install the dependencies when we run `pod install` in the old architecture.
@@ -32,6 +31,9 @@ Pod::Spec.new do |s|
     s.dependency "RCTRequired"
     s.dependency "RCTTypeSafety"
     s.dependency "ReactCommon/turbomodule/core"
+    install_modules_dependencies(s)
+  else
+    s.dependency "React-Core"
   end
 end
 


### PR DESCRIPTION
When running a project with RN 0.75 following is printed:
```
[Codegen] Found @bam.tech/react-native-image-resizer
[Codegen] CodegenConfig Deprecated Setup for @bam.tech/react-native-image-resizer.
    The configuration file still contains the codegen in the libraries array.
    If possible, replace it with a single object.
  
BEFORE:
    {
      // ...
      "codegenConfig": {
        "libraries": [
          {
            "name": "libName1",
            "type": "all|components|modules",
            "jsSrcsRoot": "libName1/js"
          },
          {
            "name": "libName2",
            "type": "all|components|modules",
            "jsSrcsRoot": "libName2/src"
          }
        ]
      }
    }

    AFTER:
    {
      "codegenConfig": {
        "name": "libraries",
        "type": "all",
        "jsSrcsRoot": "."
      }
    }
    ```